### PR TITLE
vscode: live theme updates via settings.json merge

### DIFF
--- a/theme-set.d/30-vscode.sh
+++ b/theme-set.d/30-vscode.sh
@@ -1,1288 +1,610 @@
 #!/bin/bash
+# VS Code Live Theme Hook - instant updates, no restart
+#
+# Safe settings.json editing via jq deep merge:
+#   jq '. * {"workbench.colorCustomizations": ...}' settings.json
+# Only touches colorCustomizations keys - all other settings preserved
+# Backups malformed JSON before fixing
 
-output_file="$HOME/.config/omarchy/current/theme/vscode_colors.json"
+settings_file="$HOME/.config/Code/User/settings.json"
 
+# Skip if VS Code not installed
 if ! command -v code >/dev/null 2>&1; then
     skipped "VS Code"
+    exit 0
 fi
 
-if [[ ! -f "$output_file" ]]; then
-    cat > "$output_file" << EOF
+# Require jq for safe JSON manipulation
+if ! command -v jq >/dev/null 2>&1; then
+    warning "VS Code: jq required for live theming"
+    exit 0
+fi
+
+# Ensure settings directory and file exist
+mkdir -p "$(dirname "$settings_file")"
+[[ ! -f "$settings_file" ]] && echo '{}' > "$settings_file"
+
+# Validate existing JSON (backup and recreate if malformed)
+if ! jq empty "$settings_file" 2>/dev/null; then
+    cp "$settings_file" "$settings_file.backup"
+    echo '{}' > "$settings_file"
+    warning "VS Code: Fixed malformed settings.json (backup created)"
+fi
+
+# Generate UI colors JSON using bypass's color mapping conventions
+# Colors without # prefix come from theme-set exports
+ui_colors=$(cat <<EOF
 {
-    "\$schema": "vscode://schemas/color-theme",
-    "name": "Omarchy",
-    "type": "",
-    "colors": {
-    // Base colors
-    "foreground":"#${normal_white}", //5
-    "disabledForeground":"#${bright_black}", //4
-    "widget.shadow":"#${normal_black}", //0
-    "selection.background":"#${normal_blue}", //D
-    "descriptionForeground":"#${bright_black}", //3
-    "errorForeground":"#${normal_red}", //8
-    "icon.foreground":"#${bright_black}", //4
+    "foreground": "#${normal_white}",
+    "disabledForeground": "#${bright_black}",
+    "widget.shadow": "#${normal_black}",
+    "selection.background": "#${normal_blue}",
+    "descriptionForeground": "#${bright_black}",
+    "errorForeground": "#${normal_red}",
+    "icon.foreground": "#${bright_black}",
 
-    // Text colors
-    "textBlockQuote.background":"#${normal_black}", //1
-    "textBlockQuote.border":"#${normal_blue}", //D
-    "textCodeBlock.background":"#${normal_black}", //0
-    "textLink.activeForeground":"#${normal_cyan}", //C
-    "textLink.foreground":"#${normal_blue}", //D
-    "textPreformat.foreground":"#${normal_blue}", //D
-    "textSeparator.foreground": "#f0f",
+    "textBlockQuote.background": "#${normal_black}",
+    "textBlockQuote.border": "#${normal_blue}",
+    "textCodeBlock.background": "#${normal_black}",
+    "textLink.activeForeground": "#${normal_cyan}",
+    "textLink.foreground": "#${normal_blue}",
+    "textPreformat.foreground": "#${normal_blue}",
 
-    // Action colors
-    "toolbar.hoverBackground":"#${normal_black}", //2
-    "toolbar.activeBackground":"#${bright_black}", //3
+    "toolbar.hoverBackground": "#${normal_black}",
+    "toolbar.activeBackground": "#${bright_black}",
 
-    // Button control
-    "button.background":"#${normal_blue}", //D
-    "button.foreground":"#${bright_white}", //7
-    "button.hoverBackground":"#${bright_black}", //4
-    "button.secondaryForeground":"#${bright_white}", //7
-    "button.secondaryBackground":"#${normal_magenta}", //E
-    "button.secondaryHoverBackground":"#${bright_black}", //4
-    "checkbox.background":"#${normal_black}", //0
-    "checkbox.foreground":"#${normal_white}", //5
+    "button.background": "#${normal_blue}",
+    "button.foreground": "#${bright_white}",
+    "button.hoverBackground": "#${bright_black}",
+    "button.secondaryForeground": "#${bright_white}",
+    "button.secondaryBackground": "#${normal_magenta}",
+    "button.secondaryHoverBackground": "#${bright_black}",
+    "checkbox.background": "#${normal_black}",
+    "checkbox.foreground": "#${normal_white}",
 
-    // Dropdown control
-    "dropdown.background":"#${normal_black}", //0
-    "dropdown.listBackground":"#${normal_black}", //0
-    "dropdown.foreground":"#${normal_white}", //5
+    "dropdown.background": "#${normal_black}",
+    "dropdown.listBackground": "#${normal_black}",
+    "dropdown.foreground": "#${normal_white}",
 
-    // Input control
-    "input.background":"#${normal_black}", //0
-    "input.foreground":"#${normal_white}", //5
-    "input.placeholderForeground":"#${bright_black}", //3
-    "inputOption.activeBackground":"#${normal_black}", //2
-    "inputOption.activeBorder":"#${bright_red}", //9
-    "inputOption.activeForeground":"#${normal_white}", //5
-    "inputValidation.errorBackground":"#${normal_red}", //8
-    "inputValidation.errorForeground":"#${normal_white}", //5
-    "inputValidation.errorBorder":"#${normal_red}", //8
-    "inputValidation.infoBackground":"#${normal_blue}", //D
-    "inputValidation.infoForeground":"#${normal_white}", //5
-    "inputValidation.infoBorder":"#${normal_blue}", //D
-    "inputValidation.warningBackground":"#${normal_yellow}", //A
-    "inputValidation.warningForeground":"#${normal_white}", //5
-    "inputValidation.warningBorder":"#${normal_yellow}", //A
+    "input.background": "#${normal_black}",
+    "input.foreground": "#${normal_white}",
+    "input.placeholderForeground": "#${bright_black}",
+    "inputOption.activeBackground": "#${normal_black}",
+    "inputOption.activeBorder": "#${bright_red}",
+    "inputOption.activeForeground": "#${normal_white}",
+    "inputValidation.errorBackground": "#${normal_red}",
+    "inputValidation.errorForeground": "#${normal_white}",
+    "inputValidation.errorBorder": "#${normal_red}",
+    "inputValidation.infoBackground": "#${normal_blue}",
+    "inputValidation.infoForeground": "#${normal_white}",
+    "inputValidation.infoBorder": "#${normal_blue}",
+    "inputValidation.warningBackground": "#${normal_yellow}",
+    "inputValidation.warningForeground": "#${normal_white}",
+    "inputValidation.warningBorder": "#${normal_yellow}",
 
-    // Scrollbar control
-    "scrollbar.shadow":"#${normal_black}", //1
-    "scrollbarSlider.activeBackground":"#${bright_black}6f", //4
-    "scrollbarSlider.background":"#${normal_black}6f", //2
-    "scrollbarSlider.hoverBackground":"#${bright_black}6f", //3
+    "scrollbar.shadow": "#${normal_black}",
+    "scrollbarSlider.activeBackground": "#${bright_black}6f",
+    "scrollbarSlider.background": "#${normal_black}6f",
+    "scrollbarSlider.hoverBackground": "#${bright_black}6f",
 
-    // Badge
-    "badge.background":"#${normal_black}", //0
-    "badge.foreground":"#${normal_white}", //5
+    "badge.background": "#${normal_black}",
+    "badge.foreground": "#${normal_white}",
 
-    // Progress bar
-    "progressBar.background":"#${bright_black}", //3
+    "progressBar.background": "#${bright_black}",
 
-    // Lists and trees
-    "list.activeSelectionBackground":"#${normal_black}", //2
-    "list.activeSelectionForeground":"#${normal_white}", //5
-    "list.dropBackground":"#${bright_white}", //7
-    "list.focusBackground":"#${normal_black}", //2
-    "list.focusForeground":"#${normal_white}", //5
-    "list.highlightForeground":"#${bright_white}", //7
-    "list.hoverBackground":"#${bright_black}", //3
-    "list.hoverForeground":"#${normal_white}", //5
-    "list.inactiveSelectionBackground":"#${normal_black}", //2
-    "list.inactiveSelectionForeground":"#${normal_white}", //5
-    "list.inactiveFocusBackground":"#${normal_black}", //2
-    "list.invalidItemForeground":"#${normal_red}", //8
-    "list.errorForeground":"#${normal_red}", //8
-    "list.warningForeground":"#${normal_yellow}", //A
-    "listFilterWidget.background":"#${normal_black}", //0
-    "listFilterWidget.noMatchesOutline":"#${normal_red}", //8
-    "list.filterMatchBackground":"#${normal_black}", //2
-    "tree.indentGuidesStroke":"#${normal_white}", //5
+    "list.activeSelectionBackground": "#${normal_black}",
+    "list.activeSelectionForeground": "#${normal_white}",
+    "list.dropBackground": "#${bright_white}",
+    "list.focusBackground": "#${normal_black}",
+    "list.focusForeground": "#${normal_white}",
+    "list.highlightForeground": "#${bright_white}",
+    "list.hoverBackground": "#${bright_black}",
+    "list.hoverForeground": "#${normal_white}",
+    "list.inactiveSelectionBackground": "#${normal_black}",
+    "list.inactiveSelectionForeground": "#${normal_white}",
+    "list.inactiveFocusBackground": "#${normal_black}",
+    "list.invalidItemForeground": "#${normal_red}",
+    "list.errorForeground": "#${normal_red}",
+    "list.warningForeground": "#${normal_yellow}",
+    "listFilterWidget.background": "#${normal_black}",
+    "listFilterWidget.noMatchesOutline": "#${normal_red}",
+    "list.filterMatchBackground": "#${normal_black}",
+    "tree.indentGuidesStroke": "#${normal_white}",
 
-    // Activity Bar
-    "activityBar.background":"#${normal_black}", //0
-    // Below is no longer supported as of 1.52
-    "activityBar.dropBackground":"#${bright_white}", //7
-    // Above is no longer supported as of 1.52
-    "activityBar.foreground":"#${normal_white}", //5
-    "activityBar.inactiveForeground":"#${bright_black}", //3
-    "activityBarBadge.background":"#${normal_blue}", //D
-    "activityBarBadge.foreground":"#${bright_white}", //7
-    "activityBar.activeBackground":"#${normal_black}", //2
+    "activityBar.background": "#${normal_black}",
+    "activityBar.foreground": "#${normal_white}",
+    "activityBar.inactiveForeground": "#${bright_black}",
+    "activityBarBadge.background": "#${normal_blue}",
+    "activityBarBadge.foreground": "#${bright_white}",
+    "activityBar.activeBackground": "#${normal_black}",
 
-    // Side Bar
-    "sideBar.background":"#${normal_black}", //1
-    "sideBar.foreground":"#${normal_white}", //5
-    "sideBar.dropBackground":"#${normal_black}6f", //2
-    "sideBarTitle.foreground":"#${normal_white}", //5
-    "sideBarSectionHeader.background":"#${bright_black}", //3
-    "sideBarSectionHeader.foreground":"#${normal_white}", //5
+    "sideBar.background": "#${normal_black}",
+    "sideBar.foreground": "#${normal_white}",
+    "sideBar.dropBackground": "#${normal_black}6f",
+    "sideBarTitle.foreground": "#${normal_white}",
+    "sideBarSectionHeader.background": "#${bright_black}",
+    "sideBarSectionHeader.foreground": "#${normal_white}",
 
-    //Minimap
-    "minimap.findMatchHighlight":"#${normal_yellow}6f", //A
-    "minimap.selectionHighlight":"#${normal_black}6f", //2
-    "minimap.errorHighlight":"#${normal_red}", //8
-    "minimap.warningHighlight":"#${normal_yellow}", //A
-    "minimap.background":"#${normal_black}", //0
-    "minimap.selectionOccurrenceHighlight":"#${bright_black}", //3
-    "minimapGutter.addedBackground":"#${normal_green}", //B
-    "minimapGutter.modifiedBackground":"#${normal_magenta}", //E
-    "minimapGutter.deletedBackground":"#${normal_red}", //8
+    "minimap.findMatchHighlight": "#${normal_yellow}6f",
+    "minimap.selectionHighlight": "#${normal_black}6f",
+    "minimap.errorHighlight": "#${normal_red}",
+    "minimap.warningHighlight": "#${normal_yellow}",
+    "minimap.background": "#${normal_black}",
+    "minimap.selectionOccurrenceHighlight": "#${bright_black}",
+    "minimapGutter.addedBackground": "#${normal_green}",
+    "minimapGutter.modifiedBackground": "#${normal_magenta}",
+    "minimapGutter.deletedBackground": "#${normal_red}",
 
-    // Editor Groups & Tabs
-    // Below is no longer supported as of 1.24
-    "editorGroup.background":"#${normal_black}", //0
-    // Above is no longer supported as of 1.24
-    "editorGroup.dropBackground":"#${normal_black}6f", //2
-    "editorGroupHeader.noTabsBackground":"#${normal_black}", //1
-    "editorGroupHeader.tabsBackground":"#${normal_black}", //1
-    "editorGroup.emptyBackground":"#${normal_black}", //0
-    "editorGroup.dropIntoPromptForeground":"#${bright_white}", //5
-    "editorGroup.dropIntoPromptBackground":"#${normal_black}", //0
-    "tab.activeBackground":"#${normal_black}", //0
-    "tab.unfocusedActiveBackground":"#${normal_black}", //0
-    "tab.activeForeground":"#${normal_white}", //5
-    "tab.inactiveBackground":"#${normal_black}", //1
-    "tab.inactiveForeground":"#${bright_black}", //3
-    "tab.unfocusedActiveForeground":"#${bright_black}", //4
-    "tab.unfocusedInactiveForeground":"#${bright_black}", //3
-    "tab.hoverBackground":"#${normal_black}", //2
-    "tab.unfocusedHoverBackground":"#${normal_black}", //2
+    "editorGroup.dropBackground": "#${normal_black}6f",
+    "editorGroupHeader.noTabsBackground": "#${normal_black}",
+    "editorGroupHeader.tabsBackground": "#${normal_black}",
+    "editorGroup.emptyBackground": "#${normal_black}",
+    "editorGroup.dropIntoPromptForeground": "#${bright_white}",
+    "editorGroup.dropIntoPromptBackground": "#${normal_black}",
+    "tab.activeBackground": "#${normal_black}",
+    "tab.unfocusedActiveBackground": "#${normal_black}",
+    "tab.activeForeground": "#${normal_white}",
+    "tab.inactiveBackground": "#${normal_black}",
+    "tab.inactiveForeground": "#${bright_black}",
+    "tab.unfocusedActiveForeground": "#${bright_black}",
+    "tab.unfocusedInactiveForeground": "#${bright_black}",
+    "tab.hoverBackground": "#${normal_black}",
+    "tab.unfocusedHoverBackground": "#${normal_black}",
+    "tab.activeModifiedBorder": "#${normal_blue}",
+    "tab.inactiveModifiedBorder": "#${normal_blue}",
+    "tab.unfocusedActiveModifiedBorder": "#${normal_blue}",
+    "tab.unfocusedInactiveModifiedBorder": "#${normal_blue}",
+    "editorPane.background": "#${normal_black}",
 
-    "tab.activeModifiedBorder":"#${normal_blue}", //D
-    "tab.inactiveModifiedBorder":"#${normal_blue}", //D
-    "tab.unfocusedActiveModifiedBorder":"#${normal_blue}", //D
-    "tab.unfocusedInactiveModifiedBorder":"#${normal_blue}", //D
-    "editorPane.background":"#${normal_black}", //0
+    "editor.background": "#${normal_black}",
+    "editor.foreground": "#${normal_white}",
+    "editorLineNumber.foreground": "#${bright_black}",
+    "editorLineNumber.activeForeground": "#${bright_black}",
+    "editorCursor.foreground": "#${normal_white}",
+    "editor.selectionBackground": "#${normal_black}",
+    "editor.inactiveSelectionBackground": "#${normal_black}",
+    "editor.selectionHighlightBackground": "#${normal_black}",
+    "editor.wordHighlightBackground": "#${normal_black}6f",
+    "editor.wordHighlightStrongBackground": "#${bright_black}6f",
+    "editor.findMatchBackground": "#${normal_yellow}6f",
+    "editor.findMatchHighlightBackground": "#${bright_red}6f",
+    "editor.findRangeHighlightBackground": "#${normal_black}6f",
+    "searchEditor.findMatchBackground": "#${normal_yellow}6f",
+    "editor.hoverHighlightBackground": "#${normal_black}6f",
+    "editor.lineHighlightBackground": "#${normal_black}",
+    "editorLink.activeForeground": "#${normal_blue}",
+    "editor.rangeHighlightBackground": "#${normal_black}6f",
+    "editorWhitespace.foreground": "#${bright_black}",
+    "editorIndentGuide.background1": "#${bright_black}",
+    "editorIndentGuide.activeBackground1": "#${bright_black}",
+    "editorInlayHint.background": "#${normal_black}",
+    "editorInlayHint.foreground": "#${normal_white}",
+    "editorInlayHint.typeBackground": "#${normal_black}",
+    "editorInlayHint.typeForeground": "#${normal_white}",
+    "editorInlayHint.parameterBackground": "#${normal_black}",
+    "editorInlayHint.parameterForeground": "#${normal_white}",
+    "editorRuler.foreground": "#${bright_black}",
 
-    // Editor colors
-    "editor.background":"#${normal_black}", //0
-    "editor.foreground":"#${normal_white}", //5
-    "editorLineNumber.foreground":"#${bright_black}", //3
-    "editorLineNumber.activeForeground":"#${bright_black}", //4
-    "editorCursor.foreground":"#${normal_white}", //5
-    "editor.selectionBackground":"#${normal_black}", //2
-    "editor.inactiveSelectionBackground":"#${normal_black}", //2
-    "editor.selectionHighlightBackground":"#${normal_black}", //1
-    "editor.wordHighlightBackground":"#${normal_black}6f", //2
-    "editor.wordHighlightStrongBackground":"#${bright_black}6f", //3
-    "editor.findMatchBackground":"#${normal_yellow}6f", //A
-    "editor.findMatchHighlightBackground":"#${bright_red}6f", //9
-    "editor.findRangeHighlightBackground":"#${normal_black}6f", //1
-    "searchEditor.findMatchBackground":"#${normal_yellow}6f", //A
-    "editor.hoverHighlightBackground":"#${normal_black}6f", //2
-    "editor.lineHighlightBackground":"#${normal_black}", //1
-    "editorLink.activeForeground":"#${normal_blue}", //D
-    "editor.rangeHighlightBackground":"#${normal_black}6f", //1
-    "editorWhitespace.foreground":"#${bright_black}", //3
-    "editorIndentGuide.background":"#${bright_black}", //3
-    "editorIndentGuide.activeBackground":"#${bright_black}", //4
-    "editorInlayHint.background":"#${normal_black}", //1
-    "editorInlayHint.foreground":"#${normal_white}", //5
-    "editorInlayHint.typeBackground":"#${normal_black}", //1
-    "editorInlayHint.typeForeground":"#${normal_white}", //5
-    "editorInlayHint.parameterBackground":"#${normal_black}", //1
-    "editorInlayHint.parameterForeground":"#${normal_white}", //5
-    "editorRuler.foreground":"#${bright_black}", //3
+    "editorCodeLens.foreground": "#${normal_black}",
+    "editorLightBulb.foreground": "#${normal_yellow}",
+    "editorLightBulbAutoFix.foreground": "#${normal_blue}",
+    "editorBracketMatch.background": "#${normal_black}",
 
-    /// CodeLens
-    "editorCodeLens.foreground":"#${normal_black}", //2
+    "editorBracketHighlight.foreground1": "#${normal_red}",
+    "editorBracketHighlight.foreground2": "#${bright_red}",
+    "editorBracketHighlight.foreground3": "#${normal_yellow}",
+    "editorBracketHighlight.foreground4": "#${normal_green}",
+    "editorBracketHighlight.foreground5": "#${normal_blue}",
+    "editorBracketHighlight.foreground6": "#${normal_magenta}",
+    "editorBracketHighlight.unexpectedBracket.foreground": "#${bright_magenta}",
+    "editorOverviewRuler.findMatchForeground": "#${normal_yellow}6f",
+    "editorOverviewRuler.rangeHighlightForeground": "#${bright_black}6f",
+    "editorOverviewRuler.selectionHighlightForeground": "#${normal_black}6f",
+    "editorOverviewRuler.wordHighlightForeground": "#${bright_white}6f",
+    "editorOverviewRuler.wordHighlightStrongForeground": "#${normal_blue}6f",
+    "editorOverviewRuler.modifiedForeground": "#${normal_magenta}",
+    "editorOverviewRuler.addedForeground": "#${normal_green}",
+    "editorOverviewRuler.deletedForeground": "#${normal_red}",
+    "editorOverviewRuler.errorForeground": "#${normal_red}",
+    "editorOverviewRuler.warningForeground": "#${normal_yellow}",
+    "editorOverviewRuler.infoForeground": "#${normal_cyan}",
+    "editorOverviewRuler.bracketMatchForeground": "#${bright_white}",
 
-    /// Lightbulb
-    "editorLightBulb.foreground":"#${normal_yellow}", //A
-    "editorLightBulbAutoFix.foreground":"#${normal_blue}", //D
+    "editorError.foreground": "#${normal_red}",
+    "editorWarning.foreground": "#${normal_yellow}",
+    "editorInfo.foreground": "#${normal_cyan}",
+    "editorHint.foreground": "#${normal_blue}",
+    "problemsErrorIcon.foreground": "#${normal_red}",
+    "problemsWarningIcon.foreground": "#${normal_yellow}",
+    "problemsInfoIcon.foreground": "#${normal_cyan}",
 
-    /// Bracket matches
-    "editorBracketMatch.background":"#${normal_black}", //2
+    "editorGutter.background": "#${normal_black}",
+    "editorGutter.modifiedBackground": "#${normal_magenta}",
+    "editorGutter.addedBackground": "#${normal_green}",
+    "editorGutter.deletedBackground": "#${normal_red}",
+    "editorGutter.commentRangeForeground": "#${bright_black}",
+    "editorGutter.foldingControlForeground": "#${normal_white}",
 
-    /// Bracket pair colorization
-    "editorBracketHighlight.foreground1":"#${normal_red}", //8
-    "editorBracketHighlight.foreground2":"#${bright_red}", //9
-    "editorBracketHighlight.foreground3":"#${normal_yellow}", //A
-    "editorBracketHighlight.foreground4":"#${normal_green}", //B
-    "editorBracketHighlight.foreground5":"#${normal_blue}", //D
-    "editorBracketHighlight.foreground6":"#${normal_magenta}", //E
-    "editorBracketHighlight.unexpectedBracket.foreground":"#${bright_magenta}", //F
-    "editorOverviewRuler.findMatchForeground":"#${normal_yellow}6f", //A
-    "editorOverviewRuler.rangeHighlightForeground":"#${bright_black}6f", //3
-    "editorOverviewRuler.selectionHighlightForeground":"#${normal_black}6f", //2
-    "editorOverviewRuler.wordHighlightForeground":"#${bright_white}6f", //7
-    "editorOverviewRuler.wordHighlightStrongForeground":"#${normal_blue}6f", //D
-    "editorOverviewRuler.modifiedForeground":"#${normal_magenta}", //E
-    "editorOverviewRuler.addedForeground":"#${normal_green}", //B
-    "editorOverviewRuler.deletedForeground":"#${normal_red}", //8
-    "editorOverviewRuler.errorForeground":"#${normal_red}", //8
-    "editorOverviewRuler.warningForeground":"#${normal_yellow}", //A
-    "editorOverviewRuler.infoForeground":"#${normal_cyan}", //C
-    "editorOverviewRuler.bracketMatchForeground":"#${bright_white}", //6
+    "diffEditor.insertedTextBackground": "#${normal_green}20",
+    "diffEditor.removedTextBackground": "#${normal_red}20",
+    "diffEditor.diagonalFill": "#${normal_black}",
 
-    /// Errors and warnings
-    "editorError.foreground":"#${normal_red}", //8
-    "editorWarning.foreground":"#${normal_yellow}", //A
-    "editorInfo.foreground":"#${normal_cyan}", //C
-    "editorHint.foreground":"#${normal_blue}", //D
-    "problemsErrorIcon.foreground":"#${normal_red}", //8
-    "problemsWarningIcon.foreground":"#${normal_yellow}", //A
-    "problemsInfoIcon.foreground":"#${normal_cyan}", //C
+    "editorWidget.foreground": "#${normal_white}",
+    "editorWidget.background": "#${normal_black}",
+    "editorSuggestWidget.background": "#${normal_black}",
+    "editorSuggestWidget.foreground": "#${normal_white}",
+    "editorSuggestWidget.focusHighlightForeground": "#${bright_white}",
+    "editorSuggestWidget.highlightForeground": "#${normal_blue}",
+    "editorSuggestWidget.selectedBackground": "#${normal_black}",
+    "editorSuggestWidget.selectedForeground": "#${bright_white}",
+    "editorHoverWidget.foreground": "#${normal_white}",
+    "editorHoverWidget.background": "#${normal_black}",
+    "debugExceptionWidget.background": "#${normal_black}",
+    "editorMarkerNavigation.background": "#${normal_black}",
+    "editorMarkerNavigationError.background": "#${normal_red}",
+    "editorMarkerNavigationWarning.background": "#${normal_yellow}",
+    "editorMarkerNavigationInfo.background": "#${normal_blue}",
+    "editorMarkerNavigationError.headerBackground": "#${normal_red}20",
+    "editorMarkerNavigationWarning.headerBackground": "#${normal_yellow}20",
+    "editorMarkerNavigationInfo.headerBackground": "#${normal_cyan}20",
 
-    /// Gutter
-    "editorGutter.background":"#${normal_black}", //0
-    "editorGutter.modifiedBackground":"#${normal_magenta}", //E
-    "editorGutter.addedBackground":"#${normal_green}", //B
-    "editorGutter.deletedBackground":"#${normal_red}", //8
-    "editorGutter.commentRangeForeground":"#${bright_black}", //4
-    "editorGutter.foldingControlForeground":"#${normal_white}", //5
+    "peekViewEditor.background": "#${normal_black}",
+    "peekViewEditorGutter.background": "#${normal_black}",
+    "peekViewEditor.matchHighlightBackground": "#${bright_red}6f",
+    "peekViewResult.background": "#${normal_black}",
+    "peekViewResult.fileForeground": "#${normal_white}",
+    "peekViewResult.lineForeground": "#${bright_black}",
+    "peekViewResult.matchHighlightBackground": "#${bright_red}6f",
+    "peekViewResult.selectionBackground": "#${normal_black}",
+    "peekViewResult.selectionForeground": "#${normal_white}",
+    "peekViewTitle.background": "#${normal_black}",
+    "peekViewTitleDescription.foreground": "#${bright_black}",
+    "peekViewTitleLabel.foreground": "#${normal_white}",
 
-    // Diff editor colors
-    "diffEditor.insertedTextBackground":"#${normal_green}20",
-    "diffEditor.removedTextBackground":"#${normal_red}20",
-    "diffEditor.diagonalFill":"#${normal_black}", //2
+    "merge.currentContentBackground": "#${normal_blue}40",
+    "merge.currentHeaderBackground": "#${normal_blue}40",
+    "merge.incomingContentBackground": "#${normal_green}60",
+    "merge.incomingHeaderBackground": "#${normal_green}60",
+    "editorOverviewRuler.currentContentForeground": "#${normal_blue}",
+    "editorOverviewRuler.incomingContentForeground": "#${normal_green}",
+    "editorOverviewRuler.commonContentForeground": "#${bright_magenta}",
 
-    // Editor widget colors
-    "editorWidget.foreground":"#${normal_white}", //5
-    "editorWidget.background":"#${normal_black}", //0
-    "editorSuggestWidget.background":"#${normal_black}", //1
-    "editorSuggestWidget.foreground":"#${normal_white}", //5
-    "editorSuggestWidget.focusHighlightForeground":"#${bright_white}", //7
-    "editorSuggestWidget.highlightForeground":"#${normal_blue}", //D
-    "editorSuggestWidget.selectedBackground":"#${normal_black}", //2
-    "editorSuggestWidget.selectedForeground":"#${bright_white}", //6
-    "editorHoverWidget.foreground":"#${normal_white}", //5
-    "editorHoverWidget.background":"#${normal_black}", //1
-    "debugExceptionWidget.background":"#${normal_black}", //1
-    "editorMarkerNavigation.background":"#${normal_black}", //1
-    "editorMarkerNavigationError.background":"#${normal_red}", //8
-    "editorMarkerNavigationWarning.background":"#${normal_yellow}", //A
-    "editorMarkerNavigationInfo.background":"#${normal_blue}", //D
-    "editorMarkerNavigationError.headerBackground":"#${normal_red}20", //8
-    "editorMarkerNavigationWarning.headerBackground":"#${normal_yellow}20", //A
-    "editorMarkerNavigationInfo.headerBackground":"#${normal_cyan}20", //C
+    "panel.background": "#${normal_black}",
+    "panel.dropBorder": "#${normal_black}6f",
+    "panelTitle.activeForeground": "#${normal_white}",
+    "panelTitle.inactiveForeground": "#${bright_black}",
 
-    // Peek view colors
-    "peekViewEditor.background":"#${normal_black}", //1
-    "peekViewEditorGutter.background":"#${normal_black}", //1
-    "peekViewEditor.matchHighlightBackground":"#${bright_red}6f", //9
-    "peekViewResult.background":"#${normal_black}", //0
-    "peekViewResult.fileForeground":"#${normal_white}", //5
-    "peekViewResult.lineForeground":"#${bright_black}", //3
-    "peekViewResult.matchHighlightBackground":"#${bright_red}6f", //9
-    "peekViewResult.selectionBackground":"#${normal_black}", //2
-    "peekViewResult.selectionForeground":"#${normal_white}", //5
-    "peekViewTitle.background":"#${normal_black}", //2
-    "peekViewTitleDescription.foreground":"#${bright_black}", //3
-    "peekViewTitleLabel.foreground":"#${normal_white}", //5
+    "statusBar.background": "#${normal_blue}",
+    "statusBar.foreground": "#${bright_white}",
+    "statusBar.debuggingBackground": "#${bright_red}",
+    "statusBar.debuggingForeground": "#${bright_white}",
+    "statusBar.noFolderBackground": "#${normal_magenta}",
+    "statusBar.noFolderForeground": "#${bright_white}",
+    "statusBarItem.activeBackground": "#${bright_black}",
+    "statusBarItem.hoverBackground": "#${normal_black}",
+    "statusBarItem.prominentForeground": "#${bright_white}",
+    "statusBarItem.prominentBackground": "#${normal_magenta}",
+    "statusBarItem.prominentHoverBackground": "#${normal_red}",
+    "statusBarItem.remoteBackground": "#${normal_green}",
+    "statusBarItem.remoteForeground": "#${bright_white}",
+    "statusBarItem.errorBackground": "#${normal_red}",
+    "statusBarItem.errorForeground": "#${bright_white}",
+    "statusBarItem.warningBackground": "#${normal_yellow}",
+    "statusBarItem.warningForeground": "#${bright_white}",
 
-    // Merge conflicts colors
-    "merge.currentContentBackground":"#${normal_blue}40", //D
-    "merge.currentHeaderBackground":"#${normal_blue}40", //D
-    "merge.incomingContentBackground":"#${normal_green}60", //B
-    "merge.incomingHeaderBackground":"#${normal_green}60", //B
-    "editorOverviewRuler.currentContentForeground":"#${normal_blue}", //D
-    "editorOverviewRuler.incomingContentForeground":"#${normal_green}", //B
-    "editorOverviewRuler.commonContentForeground":"#${bright_magenta}", //F
+    "titleBar.activeBackground": "#${normal_black}",
+    "titleBar.activeForeground": "#${normal_white}",
+    "titleBar.inactiveBackground": "#${normal_black}",
+    "titleBar.inactiveForeground": "#${bright_black}",
 
-    // Panel colors
-    "panel.background":"#${normal_black}", //0
-    // Below is no longer supported as of 1.47
-    "panel.dropBackground":"#${normal_black}6f", //1
-    // Above is no longer supported as of 1.47
-    "panel.dropBorder":"#${normal_black}6f", //1
-    "panelTitle.activeForeground":"#${normal_white}", //5
-    "panelTitle.inactiveForeground":"#${bright_black}", //3
+    "menubar.selectionForeground": "#${normal_white}",
+    "menubar.selectionBackground": "#${normal_black}",
+    "menu.foreground": "#${normal_white}",
+    "menu.background": "#${normal_black}",
+    "menu.selectionForeground": "#${normal_white}",
+    "menu.selectionBackground": "#${normal_black}",
+    "menu.separatorBackground": "#${bright_white}",
 
-    // Status Bar colors
-    "statusBar.background":"#${normal_blue}", //D
-    "statusBar.foreground":"#${bright_white}", //7
-    "statusBar.debuggingBackground":"#${bright_red}", //9
-    "statusBar.debuggingForeground":"#${bright_white}", //7
-    "statusBar.noFolderBackground":"#${normal_magenta}", //E
-    "statusBar.noFolderForeground":"#${bright_white}", //7
-    "statusBarItem.activeBackground":"#${bright_black}", //3
-    "statusBarItem.hoverBackground":"#${normal_black}", //2
-    "statusBarItem.prominentForeground":"#${bright_white}", //7
-    "statusBarItem.prominentBackground":"#${normal_magenta}", //E
-    "statusBarItem.prominentHoverBackground":"#${normal_red}", //8
-    "statusBarItem.remoteBackground":"#${normal_green}", //B
-    "statusBarItem.remoteForeground":"#${bright_white}", //7
-    "statusBarItem.errorBackground":"#${normal_red}", //8
-    "statusBarItem.errorForeground":"#${bright_white}", //7
-    "statusBarItem.warningBackground":"#${normal_yellow}", //A
-    "statusBarItem.warningForeground":"#${bright_white}", //7
+    "commandCenter.foreground": "#${normal_white}",
+    "commandCenter.activeForeground": "#${bright_white}",
+    "commandCenter.background": "#${normal_black}",
+    "commandCenter.activeBackground": "#${normal_black}",
 
-    // Title Bar colors
-    "titleBar.activeBackground":"#${normal_black}", //0
-    "titleBar.activeForeground":"#${normal_white}", //5
-    "titleBar.inactiveBackground":"#${normal_black}", //1
-    "titleBar.inactiveForeground":"#${bright_black}", //3
+    "notificationCenterHeader.foreground": "#${normal_white}",
+    "notificationCenterHeader.background": "#${normal_black}",
+    "notifications.foreground": "#${normal_white}",
+    "notifications.background": "#${normal_black}",
+    "notificationLink.foreground": "#${normal_blue}",
+    "notificationsErrorIcon.foreground": "#${normal_red}",
+    "notificationsWarningIcon.foreground": "#${normal_yellow}",
+    "notificationsInfoIcon.foreground": "#${normal_blue}",
 
-    // Menu Bar colors
-    "menubar.selectionForeground":"#${normal_white}", //5
-    "menubar.selectionBackground":"#${normal_black}", //1
-    "menu.foreground":"#${normal_white}", //5
-    "menu.background":"#${normal_black}", //1
-    "menu.selectionForeground":"#${normal_white}", //5
-    "menu.selectionBackground":"#${normal_black}", //2
-    "menu.separatorBackground":"#${bright_white}", //7
+    "banner.background": "#${normal_black}",
+    "banner.foreground": "#${normal_white}",
+    "banner.iconForeground": "#${normal_blue}",
 
-    // Command Center colors
-    "commandCenter.foreground":"#${normal_white}", //5
-    "commandCenter.activeForeground":"#${bright_white}", //7
-    "commandCenter.background":"#${normal_black}", //0
-    "commandCenter.activeBackground":"#${normal_black}", //1
+    "extensionButton.prominentBackground": "#${normal_green}",
+    "extensionButton.prominentForeground": "#${bright_white}",
+    "extensionButton.prominentHoverBackground": "#${normal_black}",
+    "extensionBadge.remoteBackground": "#${bright_red}",
+    "extensionBadge.remoteForeground": "#${bright_white}",
+    "extensionIcon.starForeground": "#${normal_yellow}",
+    "extensionIcon.verifiedForeground": "#${normal_blue}",
+    "extensionIcon.preReleaseForeground": "#${bright_red}",
 
-    // Notification colors
-    "notificationCenterHeader.foreground":"#${normal_white}", //5
-    "notificationCenterHeader.background":"#${normal_black}", //1
-    "notifications.foreground":"#${normal_white}", //5
-    "notifications.background":"#${normal_black}", //2
-    "notificationLink.foreground":"#${normal_blue}", //D
-    "notificationsErrorIcon.foreground":"#${normal_red}", //8
-    "notificationsWarningIcon.foreground":"#${normal_yellow}", //A
-    "notificationsInfoIcon.foreground":"#${normal_blue}", //D
+    "pickerGroup.foreground": "#${bright_black}",
+    "quickInput.background": "#${normal_black}",
+    "quickInput.foreground": "#${normal_white}",
+    "quickInputList.focusBackground": "#${bright_black}",
+    "quickInputList.focusForeground": "#${bright_white}",
+    "quickInputList.focusIconForeground": "#${bright_white}",
 
-    // Below is no longer supported as of 1.21
-    "notification.background":"#${normal_black}", //2
-    "notification.foreground":"#${normal_white}", //5
-    "notification.buttonBackground":"#${normal_blue}", //D
-    "notification.buttonHoverBackground":"#${normal_black}", //2
-    "notification.buttonForeground":"#${bright_white}", //7
-    "notification.infoBackground":"#${normal_cyan}", //C
-    "notification.infoForeground":"#${bright_white}", //7
-    "notification.warningBackground":"#${normal_yellow}", //A
-    "notification.warningForeground":"#${bright_white}", //7
-    "notification.errorBackground":"#${normal_red}", //8
-    "notification.errorForeground":"#${bright_white}", //7
-    // Above is no longer supported as of 1.21
-    //
-    // Banner colors
-    "banner.background":"#${normal_black}", //2
-    "banner.foreground":"#${normal_white}", //5
-    "banner.iconForeground":"#${normal_blue}", //D
+    "keybindingLabel.background": "#${normal_black}",
+    "keybindingLabel.foreground": "#${normal_white}",
+    "keybindingTable.headerBackground": "#${normal_black}",
+    "keybindingTable.rowsBackground": "#${normal_black}",
 
-    // Extensions colors
-    "extensionButton.prominentBackground":"#${normal_green}", //B
-    "extensionButton.prominentForeground":"#${bright_white}", //7
-    "extensionButton.prominentHoverBackground":"#${normal_black}", //2
-    "extensionBadge.remoteBackground":"#${bright_red}", //9
-    "extensionBadge.remoteForeground":"#${bright_white}", //7
-    "extensionIcon.starForeground":"#${normal_yellow}", //A
-    "extensionIcon.verifiedForeground":"#${normal_blue}", //D
-    "extensionIcon.preReleaseForeground":"#${bright_red}", //9
+    "terminal.background": "#${normal_black}",
+    "terminal.foreground": "#${normal_white}",
+    "terminal.ansiBlack": "#${normal_black}",
+    "terminal.ansiRed": "#${normal_red}",
+    "terminal.ansiGreen": "#${normal_green}",
+    "terminal.ansiYellow": "#${normal_yellow}",
+    "terminal.ansiBlue": "#${normal_blue}",
+    "terminal.ansiMagenta": "#${normal_magenta}",
+    "terminal.ansiCyan": "#${normal_cyan}",
+    "terminal.ansiWhite": "#${normal_white}",
+    "terminal.ansiBrightBlack": "#${bright_black}",
+    "terminal.ansiBrightRed": "#${bright_red}",
+    "terminal.ansiBrightGreen": "#${bright_green}",
+    "terminal.ansiBrightYellow": "#${bright_yellow}",
+    "terminal.ansiBrightBlue": "#${bright_blue}",
+    "terminal.ansiBrightMagenta": "#${bright_magenta}",
+    "terminal.ansiBrightCyan": "#${bright_cyan}",
+    "terminal.ansiBrightWhite": "#${bright_white}",
+    "terminalCursor.foreground": "#${normal_white}",
 
-    // Quick picker colors
-    "pickerGroup.foreground":"#${bright_black}", //3
-    "quickInput.background":"#${normal_black}", //1
-    "quickInput.foreground":"#${normal_white}", //5
-    "quickInputList.focusBackground":"#${bright_black}", //3
-    "quickInputList.focusForeground":"#${bright_white}", //7
-    "quickInputList.focusIconForeground":"#${bright_white}", //7
+    "debugToolBar.background": "#${normal_black}",
+    "debugView.stateLabelForeground": "#${bright_white}",
+    "debugView.stateLabelBackground": "#${normal_blue}",
+    "debugView.valueChangedHighlight": "#${normal_blue}",
+    "debugTokenExpression.name": "#${normal_magenta}",
+    "debugTokenExpression.value": "#${normal_white}",
+    "debugTokenExpression.string": "#${normal_green}",
+    "debugTokenExpression.boolean": "#${bright_red}",
+    "debugTokenExpression.number": "#${bright_red}",
+    "debugTokenExpression.error": "#${normal_red}",
 
-    // Keybinding label colors
-    "keybindingLabel.background":"#${normal_black}", //2
-    "keybindingLabel.foreground":"#${normal_white}", //5
+    "testing.iconFailed": "#${normal_red}",
+    "testing.iconErrored": "#${bright_magenta}",
+    "testing.iconPassed": "#${normal_green}",
+    "testing.runAction": "#${bright_black}",
+    "testing.iconQueued": "#${normal_yellow}",
+    "testing.iconUnset": "#${bright_black}",
+    "testing.iconSkipped": "#${normal_magenta}",
+    "testing.peekHeaderBackground": "#${normal_black}",
+    "testing.message.error.decorationForeground": "#${normal_white}",
+    "testing.message.error.lineBackground": "#${normal_red}20",
+    "testing.message.info.decorationForeground": "#${normal_white}",
+    "testing.message.info.lineBackground": "#${normal_blue}20",
 
-    // Keybinding shortcut table colors
-    "keybindingTable.headerBackground":"#${normal_black}", //2
-    "keybindingTable.rowsBackground":"#${normal_black}", //1
+    "welcomePage.background": "#${normal_black}",
+    "welcomePage.progress.background": "#${bright_black}",
+    "welcomePage.progress.foreground": "#${normal_blue}",
+    "welcomePage.tileBackground": "#${normal_black}",
+    "welcomePage.tileHoverBackground": "#${normal_black}",
+    "walkThrough.embeddedEditorBackground": "#${normal_black}",
 
-    // Integrated terminal colors
-    "terminal.background":"#${normal_black}", //0
-    "terminal.foreground":"#${normal_white}", //5
-    "terminal.ansiBlack":"#${normal_black}", //0
-    "terminal.ansiRed":"#${normal_red}", //8
-    "terminal.ansiGreen":"#${normal_green}", //B
-    "terminal.ansiYellow":"#${normal_yellow}", //A
-    "terminal.ansiBlue":"#${normal_blue}", //D
-    "terminal.ansiMagenta":"#${normal_magenta}", //E
-    "terminal.ansiCyan":"#${normal_cyan}", //C
-    "terminal.ansiWhite":"#${normal_white}", //5
-    "terminal.ansiBrightBlack":"#${bright_black}", //3
-    "terminal.ansiBrightRed":"#${normal_red}", //8
-    "terminal.ansiBrightGreen":"#${normal_green}", //B
-    "terminal.ansiBrightYellow":"#${normal_yellow}", //A
-    "terminal.ansiBrightBlue":"#${normal_blue}", //D
-    "terminal.ansiBrightMagenta":"#${normal_magenta}", //E
-    "terminal.ansiBrightCyan":"#${normal_cyan}", //C
-    "terminal.ansiBrightWhite":"#${bright_white}", //7
-    "terminalCursor.foreground":"#${normal_white}", //5
-    "terminalOverviewRuler.cursorForeground": "#ff0000",
-    "terminalOverviewRuler.findMatchForeground": "#ff0000",
+    "gitDecoration.addedResourceForeground": "#${normal_green}",
+    "gitDecoration.modifiedResourceForeground": "#${normal_magenta}",
+    "gitDecoration.deletedResourceForeground": "#${normal_red}",
+    "gitDecoration.renamedResourceForeground": "#${normal_cyan}",
+    "gitDecoration.stageModifiedResourceForeground": "#${normal_magenta}",
+    "gitDecoration.stageDeletedResourceForeground": "#${normal_red}",
+    "gitDecoration.untrackedResourceForeground": "#${bright_red}",
+    "gitDecoration.ignoredResourceForeground": "#${bright_black}",
+    "gitDecoration.conflictingResourceForeground": "#${normal_yellow}",
+    "gitDecoration.submoduleResourceForeground": "#${bright_magenta}",
 
-    // Debug colors
-    "debugToolBar.background":"#${normal_black}", //1
-    "debugView.stateLabelForeground":"#${bright_white}", //7
-    "debugView.stateLabelBackground":"#${normal_blue}", //D
-    "debugView.valueChangedHighlight":"#${normal_blue}", //D
-    "debugTokenExpression.name":"#${normal_magenta}", //E
-    "debugTokenExpression.value":"#${normal_white}", //5
-    "debugTokenExpression.string":"#${normal_green}", //B
-    "debugTokenExpression.boolean":"#${bright_red}", //9
-    "debugTokenExpression.number":"#${bright_red}", //9
-    "debugTokenExpression.error":"#${normal_red}", //8
+    "settings.headerForeground": "#${normal_white}",
+    "settings.modifiedItemIndicator": "#${normal_blue}",
+    "settings.dropdownBackground": "#${normal_black}",
+    "settings.dropdownForeground": "#${normal_white}",
+    "settings.checkboxBackground": "#${normal_black}",
+    "settings.checkboxForeground": "#${normal_white}",
+    "settings.rowHoverBackground": "#${normal_black}",
+    "settings.textInputBackground": "#${normal_black}",
+    "settings.textInputForeground": "#${normal_white}",
+    "settings.numberInputBackground": "#${normal_black}",
+    "settings.numberInputForeground": "#${normal_white}",
+    "settings.focusedRowBackground": "#${normal_black}",
+    "settings.headerBorder": "#${normal_white}",
+    "settings.sashBorder": "#${normal_white}",
 
-    // Testing colors
-    "testing.iconFailed":"#${normal_red}", //8
-    "testing.iconErrored":"#${bright_magenta}", //F
-    "testing.iconPassed":"#${normal_green}", //B
-    "testing.runAction":"#${bright_black}", //4
-    "testing.iconQueued":"#${normal_yellow}", //A
-    "testing.iconUnset":"#${bright_black}", //4
-    "testing.iconSkipped":"#${normal_magenta}", //E
+    "breadcrumb.foreground": "#${normal_white}",
+    "breadcrumb.background": "#${normal_black}",
+    "breadcrumb.focusForeground": "#${bright_white}",
+    "breadcrumb.activeSelectionForeground": "#${bright_white}",
+    "breadcrumbPicker.background": "#${normal_black}",
 
-    "testing.peekHeaderBackground":"#${normal_black}", //1
-    "testing.message.error.decorationForeground":"#${normal_white}", //5
-    "testing.message.error.lineBackground":"#${normal_red}20", //8
-    "testing.message.info.decorationForeground":"#${normal_white}", //5
-    "testing.message.info.lineBackground":"#${normal_blue}20", //D
+    "editor.snippetTabstopHighlightBackground": "#${normal_black}",
+    "editor.snippetFinalTabstopHighlightBackground": "#${bright_black}",
 
-    // Welcome page colors
-    "welcomePage.background":"#${normal_black}", //0
+    "symbolIcon.arrayForeground": "#${normal_white}",
+    "symbolIcon.booleanForeground": "#${bright_red}",
+    "symbolIcon.classForeground": "#${normal_yellow}",
+    "symbolIcon.constantForeground": "#${bright_red}",
+    "symbolIcon.constructorForeground": "#${normal_blue}",
+    "symbolIcon.enumeratorForeground": "#${bright_red}",
+    "symbolIcon.enumeratorMemberForeground": "#${normal_blue}",
+    "symbolIcon.eventForeground": "#${normal_yellow}",
+    "symbolIcon.fieldForeground": "#${normal_red}",
+    "symbolIcon.fileForeground": "#${normal_white}",
+    "symbolIcon.folderForeground": "#${normal_white}",
+    "symbolIcon.functionForeground": "#${normal_blue}",
+    "symbolIcon.interfaceForeground": "#${normal_blue}",
+    "symbolIcon.keywordForeground": "#${normal_magenta}",
+    "symbolIcon.methodForeground": "#${normal_blue}",
+    "symbolIcon.moduleForeground": "#${normal_white}",
+    "symbolIcon.namespaceForeground": "#${normal_white}",
+    "symbolIcon.nullForeground": "#${bright_magenta}",
+    "symbolIcon.numberForeground": "#${bright_red}",
+    "symbolIcon.propertyForeground": "#${normal_white}",
+    "symbolIcon.snippetForeground": "#${normal_white}",
+    "symbolIcon.stringForeground": "#${normal_green}",
+    "symbolIcon.structForeground": "#${normal_yellow}",
+    "symbolIcon.textForeground": "#${normal_white}",
+    "symbolIcon.variableForeground": "#${normal_red}",
 
-    // Below is no longer supported as of 1.63
-    "welcomePage.buttonBackground":"#${normal_black}", //1
-    "welcomePage.buttonHoverBackground":"#${normal_black}", //2
+    "debugIcon.breakpointForeground": "#${normal_red}",
+    "debugIcon.breakpointDisabledForeground": "#${bright_black}",
+    "debugIcon.breakpointUnverifiedForeground": "#${normal_black}",
+    "debugIcon.breakpointCurrentStackframeForeground": "#${normal_yellow}",
+    "debugIcon.breakpointStackframeForeground": "#${bright_magenta}",
+    "debugIcon.startForeground": "#${normal_green}",
+    "debugIcon.pauseForeground": "#${normal_blue}",
+    "debugIcon.stopForeground": "#${normal_red}",
+    "debugIcon.disconnectForeground": "#${normal_red}",
+    "debugIcon.restartForeground": "#${normal_green}",
+    "debugIcon.stepOverForeground": "#${normal_blue}",
+    "debugIcon.stepIntoForeground": "#${normal_cyan}",
+    "debugIcon.stepOutForeground": "#${normal_magenta}",
+    "debugIcon.continueForeground": "#${normal_green}",
+    "debugIcon.stepBackForeground": "#${bright_magenta}",
+    "debugConsole.infoForeground": "#${normal_white}",
+    "debugConsole.warningForeground": "#${normal_yellow}",
+    "debugConsole.errorForeground": "#${normal_red}",
+    "debugConsole.sourceForeground": "#${normal_white}",
+    "debugConsoleInputIcon.foreground": "#${normal_white}",
 
-    // Above is no longer supported as of 1.63
-    "welcomePage.progress.background":"#${bright_black}", //3
-    "welcomePage.progress.foreground":"#${normal_blue}", //D
-    "welcomePage.tileBackground":"#${normal_black}", //1
-    "welcomePage.tileHoverBackground":"#${normal_black}", //2
-    "walkThrough.embeddedEditorBackground":"#${normal_black}", //0
-    // Git colors
-    "gitDecoration.addedResourceForeground":"#${normal_green}", //B
-    "gitDecoration.modifiedResourceForeground":"#${normal_magenta}", //E
-    "gitDecoration.deletedResourceForeground":"#${normal_red}", //8
-    "gitDecoration.renamedResourceForeground":"#${normal_cyan}", //C
-    "gitDecoration.stageModifiedResourceForeground":"#${normal_magenta}", //E
-    "gitDecoration.stageDeletedResourceForeground":"#${normal_red}", //8
-    "gitDecoration.untrackedResourceForeground":"#${bright_red}", //9
-    "gitDecoration.ignoredResourceForeground":"#${bright_black}", //3
-    "gitDecoration.conflictingResourceForeground":"#${normal_yellow}", //A
-    "gitDecoration.submoduleResourceForeground":"#${bright_magenta}", //F
-    // Settings Editor colors
-    "settings.headerForeground":"#${normal_white}", //5
-    "settings.modifiedItemIndicator":"#${normal_blue}", //D
+    "notebook.editorBackground": "#${normal_black}",
+    "notebook.cellBorderColor": "#${bright_black}",
+    "notebook.cellHoverBackground": "#${normal_black}",
+    "notebook.cellToolbarSeparator": "#${normal_black}",
+    "notebook.cellEditorBackground": "#${normal_black}",
+    "notebook.focusedCellBackground": "#${normal_black}",
+    "notebook.focusedCellBorder": "#${normal_blue}",
+    "notebook.focusedEditorBorder": "#${normal_blue}",
+    "notebook.inactiveFocusedCellBorder": "#${bright_black}",
+    "notebook.selectedCellBackground": "#${normal_black}",
+    "notebookStatusErrorIcon.foreground": "#${normal_red}",
+    "notebookStatusRunningIcon.foreground": "#${normal_cyan}",
+    "notebookStatusSuccessIcon.foreground": "#${normal_green}",
 
-    // Below was introduced temporarily in 1.26
-    "settings.modifiedItemForeground":"#${normal_green}", //B
+    "charts.foreground": "#${normal_white}",
+    "charts.lines": "#${normal_white}",
+    "charts.red": "#${normal_red}",
+    "charts.blue": "#${normal_blue}",
+    "charts.yellow": "#${normal_yellow}",
+    "charts.orange": "#${bright_red}",
+    "charts.green": "#${normal_green}",
+    "charts.purple": "#${normal_magenta}",
+    "ports.iconRunningProcessForeground": "#${bright_red}"
+}
+EOF
+)
 
-    // Above was introduced temporarily in 1.26
-    "settings.dropdownBackground":"#${normal_black}", //1
-    "settings.dropdownForeground":"#${normal_white}", //5
-
-    "settings.checkboxBackground":"#${normal_black}", //1
-    "settings.checkboxForeground":"#${normal_white}", //5
-    "settings.rowHoverBackground":"#${normal_black}", //2
-    "settings.textInputBackground":"#${normal_black}", //1
-    "settings.textInputForeground":"#${normal_white}", //5
-    "settings.numberInputBackground":"#${normal_black}", //1
-    "settings.numberInputForeground":"#${normal_white}", //5
-    "settings.focusedRowBackground":"#${normal_black}", //2
-
-    "settings.headerBorder":"#${normal_white}", //5
-    "settings.sashBorder":"#${normal_white}", //5
-    // Breadcrumbs colors
-    "breadcrumb.foreground":"#${normal_white}", //5
-    "breadcrumb.background":"#${normal_black}", //1
-    "breadcrumb.focusForeground":"#${bright_white}", //6
-    "breadcrumb.activeSelectionForeground":"#${bright_white}", //7
-    "breadcrumbPicker.background":"#${normal_black}", //1
-    // Snippets colors
-    "editor.snippetTabstopHighlightBackground":"#${normal_black}", //2
-    "editor.snippetFinalTabstopHighlightBackground":"#${bright_black}", //3
-
-    // Symbol Icons colors
-    "symbolIcon.arrayForeground":"#${normal_white}", //5
-    "symbolIcon.booleanForeground":"#${bright_red}", //9
-    "symbolIcon.classForeground":"#${normal_yellow}", //A
-    "symbolIcon.colorForeground": "#f0f",
-    "symbolIcon.constantForeground":"#${bright_red}", //9
-    "symbolIcon.constructorForeground":"#${normal_blue}", //D
-    "symbolIcon.enumeratorForeground":"#${bright_red}", //9
-    "symbolIcon.enumeratorMemberForeground":"#${normal_blue}", //D
-    "symbolIcon.eventForeground":"#${normal_yellow}", //A
-    "symbolIcon.fieldForeground":"#${normal_red}", //8
-    "symbolIcon.fileForeground":"#${normal_white}", //5
-    "symbolIcon.folderForeground":"#${normal_white}", //5
-    "symbolIcon.functionForeground":"#${normal_blue}", //D,
-    "symbolIcon.interfaceForeground":"#${normal_blue}", //D
-    "symbolIcon.keyForeground": "#f0f",
-    "symbolIcon.keywordForeground":"#${normal_magenta}", //E
-    "symbolIcon.methodForeground":"#${normal_blue}", //D
-    "symbolIcon.moduleForeground":"#${normal_white}", //5
-    "symbolIcon.namespaceForeground":"#${normal_white}", //5
-    "symbolIcon.nullForeground":"#${bright_magenta}", //F
-    "symbolIcon.numberForeground":"#${bright_red}", //9
-    "symbolIcon.objectForeground": "#f0f",
-    "symbolIcon.operatorForeground": "#f0f",
-    "symbolIcon.packageForeground": "#f0f",
-    "symbolIcon.propertyForeground":"#${normal_white}", //5
-    "symbolIcon.referenceForeground": "#f0f",
-    "symbolIcon.snippetForeground":"#${normal_white}", //5
-    "symbolIcon.stringForeground":"#${normal_green}", //B
-    "symbolIcon.structForeground":"#${normal_yellow}", //A
-    "symbolIcon.textForeground":"#${normal_white}", //5
-    "symbolIcon.typeParameterForeground": "#f0f",
-    "symbolIcon.unitForeground": "#f0f",
-    "symbolIcon.variableForeground":"#${normal_red}", //8
-
-    // Debug Icons colors
-    "debugIcon.breakpointForeground":"#${normal_red}", //8
-    "debugIcon.breakpointDisabledForeground":"#${bright_black}", //4
-    "debugIcon.breakpointUnverifiedForeground":"#${normal_black}", //2
-    "debugIcon.breakpointCurrentStackframeForeground":"#${normal_yellow}", //A
-    "debugIcon.breakpointStackframeForeground":"#${bright_magenta}", //F
-    "debugIcon.startForeground":"#${normal_green}", //B
-    "debugIcon.pauseForeground":"#${normal_blue}", //D
-    "debugIcon.stopForeground":"#${normal_red}", //8
-    "debugIcon.disconnectForeground":"#${normal_red}", //8
-    "debugIcon.restartForeground":"#${normal_green}", //B
-    "debugIcon.stepOverForeground":"#${normal_blue}", //D
-    "debugIcon.stepIntoForeground":"#${normal_cyan}", //C
-    "debugIcon.stepOutForeground":"#${normal_magenta}", //E
-    "debugIcon.continueForeground":"#${normal_green}", //B
-    "debugIcon.stepBackForeground":"#${bright_magenta}", //F
-    "debugConsole.infoForeground":"#${normal_white}", //5
-    "debugConsole.warningForeground":"#${normal_yellow}", //A
-    "debugConsole.errorForeground":"#${normal_red}", //8
-    "debugConsole.sourceForeground":"#${normal_white}", //5
-    "debugConsoleInputIcon.foreground":"#${normal_white}", //5
-    // Notebook colors
-    "notebook.editorBackground":"#${normal_black}", //0
-    "notebook.cellBorderColor":"#${bright_black}", //3
-    "notebook.cellHoverBackground":"#${normal_black}", //1
-
-    "notebook.cellToolbarSeparator":"#${normal_black}", //2
-    "notebook.cellEditorBackground":"#${normal_black}", //0
-    "notebook.focusedCellBackground":"#${normal_black}", //2
-    "notebook.focusedCellBorder":"#${normal_blue}", //D
-    "notebook.focusedEditorBorder":"#${normal_blue}", //D
-    "notebook.inactiveFocusedCellBorder":"#${bright_black}", //3
-
-    "notebook.selectedCellBackground":"#${normal_black}", //2
-
-    "notebookStatusErrorIcon.foreground":"#${normal_red}", //8
-    "notebookStatusRunningIcon.foreground":"#${normal_cyan}", //C
-    "notebookStatusSuccessIcon.foreground":"#${normal_green}", //B
-    // Chart colors
-    "charts.foreground":"#${normal_white}", //5
-    "charts.lines":"#${normal_white}", //5
-    "charts.red":"#${normal_red}", //8
-    "charts.blue":"#${normal_blue}", //D
-    "charts.yellow":"#${normal_yellow}", //A
-    "charts.orange":"#${bright_red}", //9
-    "charts.green":"#${normal_green}", //B
-    "charts.purple":"#${normal_magenta}", //E
-    // Ports Colors
-    "ports.iconRunningProcessForeground":"#${bright_red}" //9
-    },
-    "tokenColors": [
-    {
-        "name": "Comment",
-        "scope": ["comment", "punctuation.definition.comment"],
-        "settings": {
-        "fontStyle": "italic",
-        "foreground":"#${bright_black}" //3
+# Generate syntax token customizations
+syntax_colors=$(cat <<EOF
+{
+    "comments": "#${bright_black}",
+    "strings": "#${normal_green}",
+    "keywords": "#${normal_magenta}",
+    "numbers": "#${bright_red}",
+    "types": "#${normal_yellow}",
+    "functions": "#${normal_blue}",
+    "variables": "#${normal_red}",
+    "textMateRules": [
+        {
+            "name": "Comment",
+            "scope": ["comment", "punctuation.definition.comment"],
+            "settings": { "fontStyle": "italic", "foreground": "#${bright_black}" }
+        },
+        {
+            "name": "Variables",
+            "scope": ["variable", "variable.parameter", "entity.name.variable"],
+            "settings": { "foreground": "#${normal_red}" }
+        },
+        {
+            "name": "Properties",
+            "scope": ["variable.other.object.property"],
+            "settings": { "foreground": "#${normal_blue}" }
+        },
+        {
+            "name": "Keywords",
+            "scope": ["keyword", "storage.modifier", "keyword.control"],
+            "settings": { "foreground": "#${normal_magenta}" }
+        },
+        {
+            "name": "Types",
+            "scope": ["keyword.type", "storage.type.primitive", "support.type"],
+            "settings": { "foreground": "#${normal_cyan}" }
+        },
+        {
+            "name": "Functions",
+            "scope": ["entity.name.function", "support.function", "variable.function"],
+            "settings": { "foreground": "#${normal_blue}" }
+        },
+        {
+            "name": "Strings",
+            "scope": ["string", "constant.other.symbol"],
+            "settings": { "foreground": "#${normal_green}" }
+        },
+        {
+            "name": "Numbers",
+            "scope": ["constant.numeric", "constant.language", "keyword.other.unit"],
+            "settings": { "foreground": "#${bright_red}" }
+        },
+        {
+            "name": "Classes",
+            "scope": ["entity.name", "support.class", "entity.name.type"],
+            "settings": { "foreground": "#${normal_yellow}" }
+        },
+        {
+            "name": "Tags",
+            "scope": ["entity.name.tag"],
+            "settings": { "foreground": "#${normal_red}" }
+        },
+        {
+            "name": "Attributes",
+            "scope": ["entity.other.attribute-name"],
+            "settings": { "foreground": "#${normal_blue}" }
+        },
+        {
+            "name": "Invalid",
+            "scope": ["invalid", "invalid.illegal"],
+            "settings": { "foreground": "#${normal_red}" }
+        },
+        {
+            "name": "Deprecated",
+            "scope": ["invalid.deprecated"],
+            "settings": { "foreground": "#${bright_magenta}" }
+        },
+        {
+            "name": "Regex",
+            "scope": ["string.regexp", "constant.character.escape"],
+            "settings": { "foreground": "#${normal_cyan}" }
+        },
+        {
+            "name": "Embedded",
+            "scope": ["punctuation.section.embedded"],
+            "settings": { "foreground": "#${bright_magenta}" }
         }
-    },
-    {
-        "name": "Variables, Parameters",
-        "scope": [
-        "variable",
-        "string constant.other.placeholder",
-        "entity.name.variable.parameter",
-        "entity.name.variable.local",
-        "variable.parameter"
-        ],
-        "settings": {
-        "foreground":"#${normal_red}" //8
-        }
-    },
-    {
-        "name": "Properties",
-        "scope": ["variable.other.object.property"],
-        "settings": {
-        "foreground":"#${normal_blue}" //D
-        }
-    },
-    {
-        "name": "Colors",
-        "scope": ["constant.other.color"],
-        "settings": {
-        "foreground":"#${normal_green}" //B
-        }
-    },
-    {
-        "name": "Invalid",
-        "scope": ["invalid", "invalid.illegal"],
-        "settings": {
-        "foreground":"#${normal_red}" //8
-        }
-    },
-    {
-        "name": "Invalid - Deprecated",
-        "scope": ["invalid.deprecated"],
-        "settings": {
-        "foreground":"#${bright_magenta}" //F
-        }
-    },
-    {
-        "name": "Keyword, Storage",
-        "scope": ["keyword", "storage.modifier"],
-        "settings": {
-        "foreground":"#${normal_magenta}" //E
-        }
-    },
-    {
-        "name": "Keyword Control",
-        "scope": [
-        "keyword.control",
-        "keyword.control.flow",
-        "keyword.control.from",
-        "keyword.control.import",
-        "keyword.control.as"
-        ],
-        "settings": {
-        "foreground":"#${normal_magenta}" //E
-        }
-    },
-    {
-        "name": "Keyword",
-        "scope": [
-        "keyword.other.using",
-        "keyword.other.namespace",
-        "keyword.other.class",
-        "keyword.other.new",
-        "keyword.other.event",
-        "keyword.other.this",
-        "keyword.other.await",
-        "keyword.other.var",
-        "keyword.other.package",
-        "keyword.other.import",
-        "variable.language.this",
-        "storage.type.ts"
-        ],
-        "settings": {
-        "foreground":"#${normal_magenta}" //E
-        }
-    },
-    {
-        "name": "Types, Primitives",
-        "scope": ["keyword.type", "storage.type.primitive"],
-        "settings": {
-        "foreground":"#${normal_cyan}" //C
-        }
-    },
-    {
-        "name": "Function",
-        "scope": ["storage.type.function"],
-        "settings": {
-        "foreground":"#${normal_blue}" //D
-        }
-    },
-    {
-        "name": "Operator, Misc",
-        "scope": [
-        "constant.other.color",
-        "punctuation",
-        "punctuation.section.class.end",
-        "meta.tag",
-        "punctuation.definition.tag",
-        "punctuation.separator.inheritance.php",
-        "punctuation.definition.tag.html",
-        "punctuation.definition.tag.begin.html",
-        "punctuation.definition.tag.end.html",
-        "keyword.other.template",
-        "keyword.other.substitution"
-        ],
-        "settings": {
-        "foreground":"#${normal_white}" //5
-        }
-    },
-    {
-        "name": "Embedded",
-        "scope": ["punctuation.section.embedded", "variable.interpolation"],
-        "settings": {
-        "foreground":"#${bright_magenta}" //F
-        }
-    },
-    {
-        "name": "Tag",
-        "scope": [
-        "entity.name.tag",
-        "meta.tag.sgml",
-        "markup.deleted.git_gutter"
-        ],
-        "settings": {
-        "foreground":"#${normal_red}" //8
-        }
-    },
-    {
-        "name": "Function, Special Method",
-        "scope": [
-        "entity.name.function",
-        "meta.function-call",
-        "variable.function",
-        "support.function",
-        "keyword.other.special-method"
-        ],
-        "settings": {
-        "foreground":"#${normal_blue}" //D
-        }
-    },
-    {
-        "name": "Block Level Variables",
-        "scope": ["meta.block variable.other"],
-        "settings": {
-        "foreground":"#${normal_red}" //8
-        }
-    },
-    {
-        "name": "Other Variable, String Link",
-        "scope": ["support.other.variable", "string.other.link"],
-        "settings": {
-        "foreground":"#${normal_red}" //8
-        }
-    },
-    {
-        "name": "Number, Constant, Function Argument, Tag Attribute, Embedded",
-        "scope": [
-        "constant.numeric",
-        "constant.language",
-        "support.constant",
-        "constant.character",
-        "constant.escape",
-        "keyword.other.unit",
-        "keyword.other"
-        ],
-        "settings": {
-        "foreground":"#${bright_red}" //9
-        }
-    },
-    {
-        "name": "String, Symbols, Inherited Class, Markup Heading",
-        "scope": [
-        "string",
-        "constant.other.symbol",
-        "constant.other.key",
-        "entity.other.inherited-class",
-        "markup.heading",
-        "markup.inserted.git_gutter",
-        "meta.group.braces.curly constant.other.object.key.js string.unquoted.label.js"
-        ],
-        "settings": {
-        "fontStyle": "",
-        "foreground":"#${normal_green}" //B
-        }
-    },
-    {
-        "name": "Class, Support",
-        "scope": [
-        "entity.name",
-        "support.type",
-        "support.class",
-        "support.other.namespace.use.php",
-        "meta.use.php",
-        "support.other.namespace.php",
-        "markup.changed.git_gutter",
-        "support.type.sys-types"
-        ],
-        "settings": {
-        "foreground":"#${normal_yellow}" //A
-        }
-    },
-    {
-        "name": "Storage Type, Import Class",
-        "scope": [
-        "storage.type",
-        "storage.modifier.package",
-        "storage.modifier.import"
-        ],
-        "settings": {
-        "foreground":"#${normal_yellow}" //A
-        }
-    },
-    {
-        "name": "Fields",
-        "scope": ["entity.name.variable.field"],
-        "settings": {
-        "foreground":"#${normal_blue}" //D
-        }
-    },
-    {
-        "name": "Entity Types",
-        "scope": ["support.type"],
-        "settings": {
-        "foreground":"#${normal_cyan}" //C
-        }
-    },
-    {
-        "name": "CSS Class and Support",
-        "scope": [
-        "source.css support.type.property-name",
-        "source.sass support.type.property-name",
-        "source.scss support.type.property-name",
-        "source.less support.type.property-name",
-        "source.stylus support.type.property-name",
-        "source.postcss support.type.property-name"
-        ],
-        "settings": {
-        "foreground":"#${normal_cyan}" //C
-        }
-    },
-    {
-        "name": "Sub-methods",
-        "scope": [
-        "entity.name.module.js",
-        "variable.import.parameter.js",
-        "variable.other.class.js"
-        ],
-        "settings": {
-        "foreground":"#${normal_red}" //8
-        }
-    },
-    {
-        "name": "Language methods",
-        "scope": ["variable.language"],
-        "settings": {
-        "fontStyle": "italic",
-        "foreground":"#${normal_red}" //8
-        }
-    },
-    {
-        "name": "entity.name.method.js",
-        "scope": ["entity.name.method.js"],
-        "settings": {
-        "fontStyle": "italic",
-        "foreground":"#${normal_blue}" //D
-        }
-    },
-    {
-        "name": "meta.method.js",
-        "scope": [
-        "meta.class-method.js entity.name.function.js",
-        "variable.function.constructor"
-        ],
-        "settings": {
-        "foreground":"#${normal_blue}" //D
-        }
-    },
-    {
-        "name": "Attributes",
-        "scope": ["entity.other.attribute-name"],
-        "settings": {
-        "foreground":"#${normal_blue}" //D
-        }
-    },
-    {
-        "name": "HTML Attributes",
-        "scope": [
-        "text.html.basic entity.other.attribute-name.html",
-        "text.html.basic entity.other.attribute-name"
-        ],
-        "settings": {
-        "fontStyle": "italic",
-        "foreground":"#${normal_yellow}" //A
-        }
-    },
-    {
-        "name": "CSS Classes",
-        "scope": ["entity.other.attribute-name.class"],
-        "settings": {
-        "foreground":"#${normal_yellow}" //A
-        }
-    },
-    {
-        "name": "CSS ID's",
-        "scope": ["source.sass keyword.control"],
-        "settings": {
-        "foreground":"#${normal_blue}" //D
-        }
-    },
-    {
-        "name": "Inserted",
-        "scope": ["markup.inserted"],
-        "settings": {
-        "foreground":"#${normal_green}" //B
-        }
-    },
-    {
-        "name": "Deleted",
-        "scope": ["markup.deleted"],
-        "settings": {
-        "foreground":"#${normal_red}" //8
-        }
-    },
-    {
-        "name": "Changed",
-        "scope": ["markup.changed"],
-        "settings": {
-        "foreground":"#${normal_magenta}" //E
-        }
-    },
-    {
-        "name": "Regular Expressions",
-        "scope": ["string.regexp"],
-        "settings": {
-        "foreground":"#${normal_cyan}" //C
-        }
-    },
-    {
-        "name": "Escape Characters",
-        "scope": ["constant.character.escape"],
-        "settings": {
-        "foreground":"#${normal_cyan}" //C
-        }
-    },
-    {
-        "name": "URL",
-        "scope": ["*url*", "*link*", "*uri*"],
-        "settings": {
-        "fontStyle": "underline"
-        }
-    },
-    {
-        "name": "Decorators",
-        "scope": [
-        "tag.decorator.js entity.name.tag.js",
-        "tag.decorator.js punctuation.definition.tag.js"
-        ],
-        "settings": {
-        "fontStyle": "italic",
-        "foreground":"#${normal_blue}" // D
-        }
-    },
-    {
-        "name": "ES7 Bind Operator",
-        "scope": [
-        "source.js constant.other.object.key.js string.unquoted.label.js"
-        ],
-        "settings": {
-        "fontStyle": "italic",
-        "foreground":"#${normal_magenta}" //E
-        }
-    },
-    {
-        "name": "JSON Key - Level 0",
-        "scope": [
-        "source.json meta.structure.dictionary.json support.type.property-name.json"
-        ],
-        "settings": {
-        "foreground":"#${normal_blue}" //D
-        }
-    },
-    {
-        "name": "JSON Key - Level 1",
-        "scope": [
-        "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
-        ],
-        "settings": {
-        "foreground":"#${normal_blue}" //D
-        }
-    },
-    {
-        "name": "JSON Key - Level 2",
-        "scope": [
-        "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
-        ],
-        "settings": {
-        "foreground":"#${normal_blue}" //D
-        }
-    },
-    {
-        "name": "JSON Key - Level 3",
-        "scope": [
-        "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
-        ],
-        "settings": {
-        "foreground":"#${normal_blue}" //D
-        }
-    },
-    {
-        "name": "JSON Key - Level 4",
-        "scope": [
-        "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
-        ],
-        "settings": {
-        "foreground":"#${normal_blue}" //D
-        }
-    },
-    {
-        "name": "JSON Key - Level 5",
-        "scope": [
-        "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
-        ],
-        "settings": {
-        "foreground":"#${normal_blue}" //D
-        }
-    },
-    {
-        "name": "JSON Key - Level 6",
-        "scope": [
-        "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
-        ],
-        "settings": {
-        "foreground":"#${normal_blue}" //D
-        }
-    },
-    {
-        "name": "JSON Key - Level 7",
-        "scope": [
-        "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
-        ],
-        "settings": {
-        "foreground":"#${normal_blue}" //D
-        }
-    },
-    {
-        "name": "JSON Key - Level 8",
-        "scope": [
-        "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
-        ],
-        "settings": {
-        "foreground":"#${normal_blue}" //D
-        }
-    },
-    {
-        "name": "Markdown - Plain",
-        "scope": [
-        "text.html.markdown",
-        "punctuation.definition.list_item.markdown"
-        ],
-        "settings": {
-        "foreground":"#${normal_white}" //5
-        }
-    },
-    {
-        "name": "Markdown - Markup Raw Inline",
-        "scope": ["text.html.markdown markup.inline.raw.markdown"],
-        "settings": {
-        "foreground":"#${normal_magenta}" //E
-        }
-    },
-    {
-        "name": "Markdown - Markup Raw Inline Punctuation",
-        "scope": [
-        "text.html.markdown markup.inline.raw.markdown punctuation.definition.raw.markdown"
-        ],
-        "settings": {
-        "foreground":"#${normal_cyan}" //C
-        }
-    },
-    {
-        "name": "Markdown - Line Break",
-        "scope": ["text.html.markdown meta.dummy.line-break"],
-        "settings": {
-        "foreground":"#${bright_black}" //3
-        }
-    },
-    {
-        "name": "Markdown - Heading",
-        "scope": [
-        "markdown.heading",
-        "markup.heading | markup.heading entity.name",
-        "markup.heading.markdown punctuation.definition.heading.markdown"
-        ],
-        "settings": {
-        "foreground":"#${normal_blue}" //D
-        }
-    },
-    {
-        "name": "Markup - Italic",
-        "scope": ["markup.italic"],
-        "settings": {
-        "fontStyle": "italic",
-        "foreground":"#${normal_red}" //8
-        }
-    },
-    {
-        "name": "Markup - Bold",
-        "scope": ["markup.bold", "markup.bold string"],
-        "settings": {
-        "fontStyle": "bold",
-        "foreground":"#${normal_red}" //8
-        }
-    },
-    {
-        "name": "Markup - Bold-Italic",
-        "scope": [
-        "markup.bold markup.italic",
-        "markup.italic markup.bold",
-        "markup.quote markup.bold",
-        "markup.bold markup.italic string",
-        "markup.italic markup.bold string",
-        "markup.quote markup.bold string"
-        ],
-        "settings": {
-        "fontStyle": "bold",
-        "foreground":"#${normal_red}" //8
-        }
-    },
-    {
-        "name": "Markup - Underline",
-        "scope": ["markup.underline"],
-        "settings": {
-        "fontStyle": "underline",
-        "foreground":"#${bright_red}" //9
-        }
-    },
-    {
-        "name": "Markdown - Blockquote",
-        "scope": ["markup.quote punctuation.definition.blockquote.markdown"],
-        "settings": {
-        "foreground":"#${normal_cyan}" //C
-        }
-    },
-    {
-        "name": "Markup - Quote",
-        "scope": ["markup.quote"],
-        "settings": {
-        "fontStyle": "italic"
-        }
-    },
-    {
-        "name": "Markdown - Link",
-        "scope": ["string.other.link.title.markdown"],
-        "settings": {
-        "foreground":"#${normal_blue}" //D
-        }
-    },
-    {
-        "name": "Markdown - Link Description",
-        "scope": ["string.other.link.description.title.markdown"],
-        "settings": {
-        "foreground":"#${normal_magenta}" //E
-        }
-    },
-    {
-        "name": "Markdown - Link Anchor",
-        "scope": ["constant.other.reference.link.markdown"],
-        "settings": {
-        "foreground":"#${normal_yellow}" //A
-        }
-    },
-    {
-        "name": "Markup - Raw Block",
-        "scope": ["markup.raw.block"],
-        "settings": {
-        "foreground":"#${normal_magenta}" //E
-        }
-    },
-    {
-        "name": "Markdown - Raw Block Fenced",
-        "scope": ["markup.raw.block.fenced.markdown"],
-        "settings": {
-        "foreground": "#00000050"
-        }
-    },
-    {
-        "name": "Markdown - Fenced Bode Block",
-        "scope": ["punctuation.definition.fenced.markdown"],
-        "settings": {
-        "foreground": "#00000050"
-        }
-    },
-    {
-        "name": "Markdown - Fenced Code Block Variable",
-        "scope": [
-        "markup.raw.block.fenced.markdown",
-        "variable.language.fenced.markdown"
-        ],
-        "settings": {
-        "foreground":"#${normal_magenta}" //E
-        }
-    },
-    {
-        "name": "Markdown - Fenced Language",
-        "scope": ["variable.language.fenced.markdown"],
-        "settings": {
-        "foreground":"#${normal_red}" //8
-        }
-    },
-    {
-        "name": "Markdown - Separator",
-        "scope": ["meta.separator"],
-        "settings": {
-        "fontStyle": "bold",
-        "foreground":"#${normal_cyan}" //C
-        }
-    },
-    {
-        "name": "Markup - Table",
-        "scope": ["markup.table"],
-        "settings": {
-        "foreground":"#${normal_magenta}" //E
-        }
-    },
-    {
-        "scope": "token.info-token",
-        "settings": {
-        "foreground":"#${normal_blue}" //D
-        }
-    },
-    {
-        "scope": "token.warn-token",
-        "settings": {
-        "foreground":"#${normal_yellow}" //A
-        }
-    },
-    {
-        "scope": "token.error-token",
-        "settings": {
-        "foreground":"#${normal_red}" //8
-        }
-    },
-    {
-        "scope": "token.debug-token",
-        "settings": {
-        "foreground":"#${normal_magenta}" //E
-        }
-    }
     ]
 }
 EOF
-fi
-
-extension_name="tintedtheming.base16-tinted-themes"
-
-install_extension() {
-    is_extension_installed=$(code --list-extensions | grep "${extension_name}")
-    if [[ -z "$is_extension_installed" ]]; then
-        code --install-extension $extension_name
-        sleep 3
-    fi
-}
-
-install_path=""
-vscode_paths=(
-    "$HOME/.vscode-oss/extensions/"
-    "$HOME/.vscode/extensions/"
 )
-find_extension_dir() {
-    for path in "${vscode_paths[@]}"; do
-        if [[ -d "$path" ]]; then
-            install_path=$(find "$path" -maxdepth 1 -type d -name "${extension_name}-*" | head -n1)
-        fi
-    done
-}
 
-modify_extension_manifest() {
-    omarchy_entry=$(cat $install_path/package.json | jq 'first(.contributes.themes[] | select(.label == "Omarchy"))')
-    if [[ -z "$omarchy_entry" ]]; then
-        omarchy_entry='{"label": "Omarchy", "uiTheme": "vs-dark", "path": "./themes/base16/omarchy.json"}'
-        new_manifest=$(cat "${install_path}/package.json" | jq --argjson theme "$omarchy_entry" '.contributes.themes += [$theme]')
-        echo "$new_manifest" > "${install_path}/package.json"
-    fi
-}
-
-install_extension
-find_extension_dir
-modify_extension_manifest
-
-install_location="$install_path/themes/base16/omarchy.json"
-cp "$output_file" "$install_location"
-
-require_restart "code"
-success "VS Code theme updated!"
-exit 0
+# Merge into settings.json (preserves all other settings)
+if jq --argjson ui "$ui_colors" \
+   --argjson syntax "$syntax_colors" \
+   '. * {
+     "workbench.colorCustomizations": $ui,
+     "editor.tokenColorCustomizations": $syntax
+   }' "$settings_file" > "$settings_file.tmp" 2>/dev/null; then
+    mv "$settings_file.tmp" "$settings_file"
+    success "VS Code"
+else
+    rm -f "$settings_file.tmp"
+    error "VS Code: Failed to update settings.json"
+fi


### PR DESCRIPTION
Safe settings.json editing via jq deep merge:
  jq '. * {"workbench.colorCustomizations": ...}'
Only touches colorCustomizations keys - all other settings preserved

- No extension dependency (removes base16-tinted-themes requirement)
- Instant updates on theme switch (no restart needed)
- Proper ANSI bright colors for terminal
- Backups malformed JSON before fixing