### PR TITLE
Add Waybar theme directory support with default fallback

### DIFF
--- a/theme-set.d/10-waybar.sh
+++ b/theme-set.d/10-waybar.sh
@@ -1,5 +1,57 @@
 #!/bin/bash
 
+THEME_NAME="${1:-}"
+THEME_DIR="$HOME/.config/omarchy/themes/$THEME_NAME"
+WAYBAR_THEME_DIR="$THEME_DIR/waybar-theme"
+WAYBAR_DIR="$HOME/.config/waybar"
+DEFAULT_WAYBAR_DIR="$HOME/.local/share/omarchy/config/waybar"
+BACKUP_ROOT="$HOME/.config/waybar-backups"
+BACKUP_DIR="$BACKUP_ROOT/$(date +%Y%m%d-%H%M%S)"
+
+restore_waybar_defaults() {
+    if [[ ! -d "$DEFAULT_WAYBAR_DIR" ]]; then
+        return 0
+    fi
+
+    mkdir -p "$WAYBAR_DIR"
+    for file in config.jsonc style.css; do
+        if [[ -L "$WAYBAR_DIR/$file" ]]; then
+            rm -f "$WAYBAR_DIR/$file"
+        fi
+        if [[ -e "$DEFAULT_WAYBAR_DIR/$file" ]]; then
+            ln -snf "$DEFAULT_WAYBAR_DIR/$file" "$WAYBAR_DIR/$file"
+        fi
+    done
+
+    if pgrep -x waybar >/dev/null; then
+        omarchy-restart-waybar
+    fi
+}
+
+if [[ -n "$THEME_NAME" && -d "$WAYBAR_THEME_DIR" ]]; then
+    mkdir -p "$WAYBAR_DIR" "$BACKUP_DIR" "$BACKUP_ROOT"
+
+    for file in config.jsonc style.css; do
+        if [[ -L "$WAYBAR_DIR/$file" ]]; then
+            rm -f "$WAYBAR_DIR/$file"
+        elif [[ -e "$WAYBAR_DIR/$file" ]]; then
+            cp -a "$WAYBAR_DIR/$file" "$BACKUP_DIR/$file"
+        fi
+
+        if [[ -e "$WAYBAR_THEME_DIR/$file" ]]; then
+            ln -snf "$WAYBAR_THEME_DIR/$file" "$WAYBAR_DIR/$file"
+        fi
+    done
+
+    if pgrep -x waybar >/dev/null; then
+        omarchy-restart-waybar
+    fi
+
+    exit 0
+fi
+
+restore_waybar_defaults
+
 output_file="$HOME/.config/omarchy/current/theme/waybar.css"
 
 if [[ ! -f "$output_file" ]]; then


### PR DESCRIPTION
## Summary

  - Install theme-provided Waybar configs when a theme includes waybar-theme/
  - Restore Omarchy’s default Waybar config.jsonc and style.css when a theme doesn’t include waybar-theme
  - Restart Waybar after switching configs

  ## Behavior

  - If the current theme has waybar-theme/, ~/.config/waybar/{config.jsonc,style.css} are symlinked to that directory
  - Otherwise, the default configs at ~/.local/share/omarchy/config/waybar are linked back in

  ## Notes

  - Leaves existing waybar.css generation intact for themes that ship only a waybar.css
  - Backups are still created when switching into a theme-provided Waybar config