### PR TITLE
fix: split gtk hook for gtk3 filter

### DIFF
--- a/theme-set.d/10-gtk3.sh
+++ b/theme-set.d/10-gtk3.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+. "$script_dir/gtk-common"
+
+strip_svg_filter_block() {
+    local input_file="$1"
+    local output_path="$2"
+
+    awk '
+        $0 ~ /^[[:space:]]*\.svg-icon[[:space:]]*\{$/ { in_block=1; next }
+        in_block && $0 ~ /^[[:space:]]*\}[[:space:]]*$/ { in_block=0; next }
+        !in_block { print }
+    ' "$input_file" > "$output_path"
+}
+
+if [ ! -d "$gtk3_dir" ]; then
+    mkdir -p "$gtk3_dir"
+fi
+
+if [ -f "$output_file" ]; then
+    if [ ! -f "$gtk3_dir/gtk.css.backup" ]; then
+        cp "$gtk3_file" "$gtk3_dir/gtk.css.backup"
+    fi
+    strip_svg_filter_block "$output_file" "$gtk3_file"
+else
+    create_dynamic_theme
+    strip_svg_filter_block "$output_file" "$gtk3_file"
+fi

--- a/theme-set.d/10-gtk4.sh
+++ b/theme-set.d/10-gtk4.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+. "$script_dir/gtk-common"
+
+if [ ! -d "$gtk4_dir" ]; then
+    mkdir -p "$gtk4_dir"
+fi
+
+if [ -f "$output_file" ]; then
+    if [ ! -f "$gtk4_dir/gtk.css.backup" ]; then
+        cp "$gtk4_file" "$gtk4_dir/gtk.css.backup"
+    fi
+    cp -f "$output_file" "$gtk4_file"
+else
+    create_dynamic_theme
+    cp "$output_file" "$gtk4_file"
+fi
+
+gsettings set org.gnome.desktop.interface gtk-theme adw-gtk3-tmp
+gsettings set org.gnome.desktop.interface gtk-theme adw-gtk3
+
+require_restart "nautilus"
+success "GTK theme updated!"
+exit 0

--- a/theme-set.d/gtk-common
+++ b/theme-set.d/gtk-common
@@ -7,7 +7,7 @@ gtk3_file="$gtk3_dir/gtk.css"
 gtk4_file="$gtk4_dir/gtk.css"
 
 create_dynamic_theme() {
-    cat > "$output_file" << EOF
+    cat > "$output_file" << EOF_THEME
     @define-color background     #${primary_background};
     @define-color foreground     #${primary_foreground};
     @define-color black          #${primary_background};
@@ -174,35 +174,5 @@ create_dynamic_theme() {
         filter: invert(79%) sepia(18%) saturate(611%) hue-rotate(192deg)
             brightness(103%) contrast(94%);
     }
-EOF
+EOF_THEME
 }
-
-if [ ! -d "$gtk3_dir" ]; then
-    mkdir -p "$gtk3_dir"
-fi
-if [ ! -d "$gtk4_dir" ]; then
-    mkdir -p "$gtk4_dir"
-fi
-
-if [ -f "$output_file" ]; then
-    if [ ! -f "$gtk3_dir/gtk.css.backup" ]; then
-        cp "$gtk3_file" "$gtk3_dir/gtk.css.backup"
-    fi
-    cp -f "$output_file" "$gtk3_file"
-
-    if [ ! -f "$gtk4_dir/gtk.css.backup" ]; then
-        cp "$gtk4_file" "$gtk4_dir/gtk.css.backup"
-    fi
-    cp -f "$output_file" "$gtk4_file"
-else
-    create_dynamic_theme
-    cp "$output_file" "$gtk3_file"
-    cp "$output_file" "$gtk4_file"
-fi
-
-gsettings set org.gnome.desktop.interface gtk-theme adw-gtk3-tmp
-gsettings set org.gnome.desktop.interface gtk-theme adw-gtk3
-
-require_restart "nautilus"
-success "GTK theme updated!"
-exit 0


### PR DESCRIPTION
## Summary
- split GTK hook into `10-gtk3.sh` and `10-gtk4.sh`
- keep the `.svg-icon { filter: ... }` only for GTK4
- ensure GTK3 output strips the `.svg-icon` block
  
## Notes 
I previously experimented with stripping the `filter:` line from gtk 3 gtk.css to reduce code size with success but I decided against that approach. The most minimal fix would just be to remove this:
https://github.com/imbypass/omarchy-theme-hook/blob/da07484597ffac446331c983e903ab043e2e6fac/theme-set.d/10-gtk.sh#L173-L176
But gtk 4 supports it.

This PR closes #26
