### PR TITLE
fix: restart xdg-desktop-portal-gtk on theme change

### DIFF
--- a/theme-set.d/10-gtk.sh
+++ b/theme-set.d/10-gtk.sh
@@ -202,6 +202,7 @@ fi
 
 gsettings set org.gnome.desktop.interface gtk-theme adw-gtk3-tmp
 gsettings set org.gnome.desktop.interface gtk-theme adw-gtk3
+pkill -f xdg-desktop-portal-gtk
 
 require_restart "nautilus"
 success "GTK theme updated!"


### PR DESCRIPTION
When restarting Nautilus, if you click 'Open With' or go into any file picker or dialogue, the desktop portal does not restart and maintains the old theme color. This change ensures that the portal is restarted so it updates to the correct theme color.