### PR TITLE
fix: Compatibility with Omarchy 3.3+ template system

### DIFF
--- a/theme-set
+++ b/theme-set
@@ -1,17 +1,17 @@
 #!/bin/bash
 
-input_file="$HOME/.config/omarchy/current/theme/alacritty.toml"
+# Omarchy 3.3+ uses colors.toml as the source of truth for theme colors.
+# Previously we read from alacritty.toml, but that file is now generated
+# from templates and may contain unrendered {{ placeholders }}.
+input_file="$HOME/.config/omarchy/current/theme/colors.toml"
 
-extract_from_section() {
-    local section="$1"
-    local color_name="$2"
-    awk -v section="[$section]" -v color="$color_name" '
-        $0 == section { in_section=1; next }
-        /^\[/ { in_section=0 }
-        in_section && $1 == color {
-            if (match($0, /(#|0x)([0-9a-fA-F]{6})/)) {
-                hex_part = substr($0, RSTART + (substr($0, RSTART, 2) == "0x" ? 2 : 1), 6)
-                print hex_part
+# Extract color value from colors.toml (flat key=value format)
+extract_color() {
+    local color_name="$1"
+    awk -v color="$color_name" '
+        $1 == color && /=/ {
+            if (match($0, /#([0-9a-fA-F]{6})/)) {
+                print substr($0, RSTART + 1, 6)
                 exit
             }
         }
@@ -77,26 +77,30 @@ require_restart() {
 
 export -f rgb2hex hex2rgb change_shade require_restart
 
-primary_foreground=$(extract_from_section "colors.primary" "foreground")
-primary_background=$(extract_from_section "colors.primary" "background")
-normal_black=$(extract_from_section "colors.normal" "black")
-normal_red=$(extract_from_section "colors.normal" "red")
-normal_green=$(extract_from_section "colors.normal" "green")
-normal_yellow=$(extract_from_section "colors.normal" "yellow")
-normal_blue=$(extract_from_section "colors.normal" "blue")
-normal_magenta=$(extract_from_section "colors.normal" "magenta")
-normal_cyan=$(extract_from_section "colors.normal" "cyan")
-normal_white=$(extract_from_section "colors.normal" "white")
-bright_black=$(extract_from_section "colors.bright" "black")
-bright_red=$(extract_from_section "colors.bright" "red")
-bright_green=$(extract_from_section "colors.bright" "green")
-bright_yellow=$(extract_from_section "colors.bright" "yellow")
-bright_blue=$(extract_from_section "colors.bright" "blue")
-bright_magenta=$(extract_from_section "colors.bright" "magenta")
-bright_cyan=$(extract_from_section "colors.bright" "cyan")
-bright_white=$(extract_from_section "colors.bright" "white")
+# Extract colors from colors.toml (Omarchy 3.3+ format)
+primary_foreground=$(extract_color "foreground")
+primary_background=$(extract_color "background")
+cursor_color=$(extract_color "cursor")
+selection_foreground=$(extract_color "selection_foreground")
+selection_background=$(extract_color "selection_background")
+normal_black=$(extract_color "color0")
+normal_red=$(extract_color "color1")
+normal_green=$(extract_color "color2")
+normal_yellow=$(extract_color "color3")
+normal_blue=$(extract_color "color4")
+normal_magenta=$(extract_color "color5")
+normal_cyan=$(extract_color "color6")
+normal_white=$(extract_color "color7")
+bright_black=$(extract_color "color8")
+bright_red=$(extract_color "color9")
+bright_green=$(extract_color "color10")
+bright_yellow=$(extract_color "color11")
+bright_blue=$(extract_color "color12")
+bright_magenta=$(extract_color "color13")
+bright_cyan=$(extract_color "color14")
+bright_white=$(extract_color "color15")
 
-export primary_background primary_foreground
+export primary_background primary_foreground cursor_color selection_foreground selection_background
 export normal_black normal_red normal_green normal_yellow normal_blue normal_magenta normal_cyan normal_white
 export bright_black bright_red bright_green bright_yellow bright_blue bright_magenta bright_cyan bright_white
 

--- a/theme-set.d/00-fish.sh
+++ b/theme-set.d/00-fish.sh
@@ -6,8 +6,7 @@ if ! command -v fish >/dev/null 2>&1; then
     skipped "Fish - Colors"
 fi
 
-if [[ ! -f "$output_file" ]]; then
-    cat > "$output_file" << EOF
+cat > "$output_file" << EOF
 set -U background '#${primary_background}'
 set -U foreground '#${primary_foreground}'
 set -U cursor '#${primary_foreground}'
@@ -36,7 +35,6 @@ set -U fish_pager_color_description \$fish_color_quote yellow
 set -U fish_pager_color_progress brwhite --background=cyan
 set -U fish_color_history_current --bold
 EOF
-fi
 
 fish source "$output_file"
 success "fish colors updated!"

--- a/theme-set.d/00-fzf.sh
+++ b/theme-set.d/00-fzf.sh
@@ -6,8 +6,7 @@ if ! command -v fish >/dev/null 2>&1; then
     skipped "Fish - FZF"
 fi
 
-if [[ ! -f "$output_file" ]]; then
-    cat > "$output_file" << EOF
+cat > "$output_file" << EOF
 set -l color00 '#${normal_black}'
 set -l color01 '#${normal_red}'
 set -l color02 '#${normal_green}'
@@ -38,7 +37,6 @@ set -Ux FZF_DEFAULT_OPTS "\$FZF_NON_COLOR_OPTS"\
 " --color=fg:\$color07,header:\$color0D,info:\$color0A,pointer:\$color0E"\
 " --color=marker:\$color0E,fg+:\$color06,prompt:\$color0A,hl+:\$color0D"
 EOF
-fi
 
 fish source "$output_file"
 success "fzf colors updated!"

--- a/theme-set.d/10-alacritty.sh
+++ b/theme-set.d/10-alacritty.sh
@@ -2,8 +2,7 @@
 
 output_file="$HOME/.config/omarchy/current/theme/alacritty.toml"
 
-if [[ ! -f "$output_file" ]]; then
-    cat > "$output_file" << EOF
+cat > "$output_file" << EOF
 [window]
 opacity = 0.9
 
@@ -34,4 +33,3 @@ magenta     = "#${bright_magenta}"
 cyan        = "#${bright_cyan}"
 white       = "#${bright_white}"
 EOF
-fi

--- a/theme-set.d/10-discord.sh
+++ b/theme-set.d/10-discord.sh
@@ -14,7 +14,7 @@ possible_paths=(
 
 create_dynamic_theme() {
 
-    cat > "$output_file" << EOF
+cat > "$output_file" << EOF
     /**
     * @name Omarchy
     * @author @bypass_

--- a/theme-set.d/10-ghostty.sh
+++ b/theme-set.d/10-ghostty.sh
@@ -2,11 +2,13 @@
 
 output_file="$HOME/.config/omarchy/current/theme/ghostty.conf"
 
-if [[ ! -f "$output_file" ]]; then
-    cat > "$output_file" << EOF
+cat > "$output_file" << EOF
 font-family = "$(omarchy-font-current)"
 background = #${primary_background}
 foreground = #${primary_foreground}
+cursor-color = #${cursor_color}
+selection-background = #${selection_background}
+selection-foreground = #${selection_foreground}
 
 palette = 0=#${normal_black}
 palette = 1=#${normal_red}
@@ -26,4 +28,3 @@ palette = 13=#${bright_magenta}
 palette = 14=#${bright_cyan}
 palette = 15=#${bright_white}
 EOF
-fi

--- a/theme-set.d/10-gtk.sh
+++ b/theme-set.d/10-gtk.sh
@@ -7,7 +7,7 @@ gtk3_file="$gtk3_dir/gtk.css"
 gtk4_file="$gtk4_dir/gtk.css"
 
 create_dynamic_theme() {
-    cat > "$output_file" << EOF
+cat > "$output_file" << EOF
     @define-color background     #${primary_background};
     @define-color foreground     #${primary_foreground};
     @define-color black          #${primary_background};

--- a/theme-set.d/10-hyprland.sh
+++ b/theme-set.d/10-hyprland.sh
@@ -2,8 +2,7 @@
 
 output_file="$HOME/.config/omarchy/current/theme/hyprland.conf"
 
-if [[ ! -f "$output_file" ]]; then
-    cat > "$output_file" << EOF
+cat > "$output_file" << EOF
 # This file is not a full hyprland configuration.
 # It is intended to be included in your main hyprland.conf.
 
@@ -13,6 +12,5 @@ general {
     border_size = 2
 }
 EOF
-fi
 
 hyprctl reload >/dev/null 2>&1

--- a/theme-set.d/10-kitty.sh
+++ b/theme-set.d/10-kitty.sh
@@ -2,8 +2,7 @@
 
 output_file="$HOME/.config/omarchy/current/theme/kitty.conf"
 
-if [[ ! -f "$output_file" ]]; then
-    cat > "$output_file" <<EOF
+cat > "$output_file" <<EOF
 background            #${primary_background}
 foreground            #${primary_foreground}
 
@@ -24,4 +23,3 @@ color13 #${bright_magenta}
 color14 #${bright_cyan}
 color15 #${bright_white}
 EOF
-fi

--- a/theme-set.d/10-mako.sh
+++ b/theme-set.d/10-mako.sh
@@ -2,8 +2,7 @@
 
 output_file="$HOME/.config/omarchy/current/theme/mako.ini"
 
-if [[ ! -f "$output_file" ]]; then
-    cat > "$output_file" << EOF
+cat > "$output_file" << EOF
 include=~/.local/share/omarchy/default/mako/core.ini
 
 text-color=#${primary_foreground}
@@ -15,6 +14,5 @@ font=$(omarchy-font-current) 12
 max-icon-size=32
 outer-margin=5
 EOF
-fi
 
 makoctl reload

--- a/theme-set.d/10-qt6ct.sh
+++ b/theme-set.d/10-qt6ct.sh
@@ -24,7 +24,7 @@ base0E=$normal_magenta
 base0F=$bright_red
 
 if [ ! -f "$new_qt_file" ]; then
-    cat > "$new_qt_file" << EOF
+cat > "$new_qt_file" << EOF
 [ColorScheme]
 active_colors=#ff${base05}, #ff${base01}, #ff${base01}, #ff${base05}, #ff${base03}, #ff${base04}, #ff${base05}, #ff${base06}, #ff${base05}, #ff${base01}, #ff${base00}, #ff${base03}, #ff${base02}, #ff${base05}, #ff${base09}, #ff${base08}, #ff${base02}, #ff${base05}, #ff${base01}, #ff${base05}, #8f${base05}
 disabled_colors=#ff${base00}, #ff${base01}, #ff${base01}, #ff${base04}, #ff${base03}, #ff${base04}, #ff${base00}, #ff${base00}, #ff${base00}, #ff${base01}, #ff${base00}, #ff${base03}, #ff${base02}, #ff${base04}, #ff${base09}, #ff${base08}, #ff${base02}, #ff${base04}, #ff${base01}, #ff${base00}, #8f${base00}

--- a/theme-set.d/10-spotify.sh
+++ b/theme-set.d/10-spotify.sh
@@ -2,7 +2,7 @@
 
 create_spicetify_styling() {
     mkdir -p "$HOME/.config/spicetify/Themes/omarchy"
-    cat > "$HOME/.config/spicetify/Themes/omarchy/user.css" << EOF
+cat > "$HOME/.config/spicetify/Themes/omarchy/user.css" << EOF
 :root,
 .encore-dark-theme,
 .encore-base-set,
@@ -54,7 +54,7 @@ create_dynamic_theme() {
     color0E=${normal_magenta}
     color0F=${bright_red}
 
-    cat > "$HOME/.config/spicetify/Themes/omarchy/color.ini" << EOF
+cat > "$HOME/.config/spicetify/Themes/omarchy/color.ini" << EOF
 [base]
 main                = ${color00}
 player              = ${color00}

--- a/theme-set.d/10-superfile.sh
+++ b/theme-set.d/10-superfile.sh
@@ -7,7 +7,7 @@ if ! command -v spf >/dev/null 2>&1; then
 fi
 
 if [ ! -f "$output_file" ]; then
-    cat > "$output_file" << EOF
+cat > "$output_file" << EOF
 
 # ========= Border =========
 file_panel_border = '#${normal_white}'

--- a/theme-set.d/10-swayosd.sh
+++ b/theme-set.d/10-swayosd.sh
@@ -2,14 +2,12 @@
 
 output_file="$HOME/.config/omarchy/current/theme/swayosd.css"
 
-if [[ ! -f "$output_file" ]]; then
-    cat > "$output_file" << EOF
+cat > "$output_file" << EOF
 @define-color background-color #${primary_background};
 @define-color border-color #${primary_foreground};
 @define-color label #${primary_foreground};
 @define-color image #${primary_foreground};
 @define-color progress ${primary_foreground};
 EOF
-fi
 
 omarchy-restart-swayosd

--- a/theme-set.d/10-vicinae.sh
+++ b/theme-set.d/10-vicinae.sh
@@ -7,7 +7,7 @@ if ! command -v vicinae >/dev/null 2>&1; then
 fi
 
 if [ ! -f "$output_file" ]; then
-    cat > "$output_file" << EOF
+cat > "$output_file" << EOF
 [meta]
 version = 1
 name = "Omarchy"

--- a/theme-set.d/10-walker.sh
+++ b/theme-set.d/10-walker.sh
@@ -2,8 +2,7 @@
 
 output_file="$HOME/.config/omarchy/current/theme/walker.css"
 
-if [[ ! -f "$output_file" ]]; then
-    cat > "$output_file" << EOF
+cat > "$output_file" << EOF
 @define-color selected-text #${normal_yellow};
 @define-color selected-vibrant #${bright_yellow};
 @define-color text #${primary_foreground};
@@ -12,4 +11,3 @@ if [[ ! -f "$output_file" ]]; then
 @define-color foreground #${primary_foreground};
 @define-color background #${primary_background};
 EOF
-fi

--- a/theme-set.d/10-waybar.sh
+++ b/theme-set.d/10-waybar.sh
@@ -2,8 +2,7 @@
 
 output_file="$HOME/.config/omarchy/current/theme/waybar.css"
 
-if [[ ! -f "$output_file" ]]; then
-    cat > "$output_file" << EOF
+cat > "$output_file" << EOF
 @define-color black #${normal_black};
 @define-color red #${normal_red};
 @define-color green #${normal_green};
@@ -23,4 +22,3 @@ if [[ ! -f "$output_file" ]]; then
 @define-color background #${primary_background};
 @define-color foreground #${primary_foreground};
 EOF
-fi

--- a/theme-set.d/20-nwg-dock-hyprland.sh
+++ b/theme-set.d/20-nwg-dock-hyprland.sh
@@ -7,8 +7,7 @@ if ! command -v nwg-dock-hyprland >/dev/null 2>&1; then
     skipped "NWG Dock"
 fi
 
-if [[ ! -f "$output_file" ]]; then
-    cat > "$output_file" << EOF
+cat > "$output_file" << EOF
 window {
     background: #${primary_background}; /* base01 */
     border-color: #${bright_black}; /* base02 */
@@ -29,12 +28,11 @@ button:hover {
     background-color: rgba($rgb_bright_black, 0.5); /* base02 */
 }
 EOF
-fi
 
 mkdir -p "$HOME/.config/nwg-dock-hyprland"
 style_file="$HOME/.config/nwg-dock-hyprland/style.css"
 if [[ ! -f $style_file ]]; then
-    cat > $style_file << EOF
+cat > $style_file << EOF
 @import url("./colors.css");
 
 window {

--- a/theme-set.d/20-zed.sh
+++ b/theme-set.d/20-zed.sh
@@ -3,7 +3,7 @@
 new_zed_file="$HOME/.config/omarchy/current/theme/zed.json"
 
 create_dynamic_theme() {
-    cat > "$new_zed_file" << EOF
+cat > "$new_zed_file" << EOF
     {
       "\$schema": "https://zed.dev/schema/themes/v0.1.0.json",
       "name": "Omarchyy",

--- a/theme-set.d/30-cursor.sh
+++ b/theme-set.d/30-cursor.sh
@@ -6,8 +6,7 @@ if ! command -v cursor >/dev/null 2>&1; then
     skipped "Cursor"
 fi
 
-if [[ ! -f "$output_file" ]]; then
-    cat > "$output_file" << EOF
+cat > "$output_file" << EOF
 {
     "\$schema": "vscode://schemas/color-theme",
     "name": "Omarchy",
@@ -1242,7 +1241,6 @@ if [[ ! -f "$output_file" ]]; then
     ]
 }
 EOF
-fi
 
 extension_name="tintedtheming.base16-tinted-themes"
 

--- a/theme-set.d/30-windsurf.sh
+++ b/theme-set.d/30-windsurf.sh
@@ -6,8 +6,7 @@ if ! command -v windsurf >/dev/null 2>&1; then
     skipped "Windsurf"
 fi
 
-if [[ ! -f "$output_file" ]]; then
-    cat > "$output_file" << EOF
+cat > "$output_file" << EOF
 {
     "\$schema": "vscode://schemas/color-theme",
     "name": "Omarchy",
@@ -1242,7 +1241,6 @@ if [[ ! -f "$output_file" ]]; then
     ]
 }
 EOF
-fi
 
 extension_name="tintedtheming.base16-tinted-themes"
 

--- a/theme-set.d/40-cava.sh
+++ b/theme-set.d/40-cava.sh
@@ -7,7 +7,7 @@ fi
 theme_template="$HOME/.config/omarchy/current/theme/cava_theme"
 
 if [ ! -f "$theme_template" ]; then
-    cat > "$theme_template" << EOF
+cat > "$theme_template" << EOF
 [color]
 gradient = 1
 gradient_count = 8

--- a/theme-set.d/40-chromium.sh
+++ b/theme-set.d/40-chromium.sh
@@ -2,9 +2,7 @@
 
 output_file="$HOME/.config/omarchy/current/theme/chromium.theme"
 
-if [[ ! -f "$output_file" ]]; then
-    cat > "$output_file" << EOF
+cat > "$output_file" << EOF
 $(hex2rgb $primary_background)
 EOF
-fi
 exit 0

--- a/theme-set.d/40-firefox.sh
+++ b/theme-set.d/40-firefox.sh
@@ -30,8 +30,7 @@ enable_userchrome
 
 mkdir -p "$default_profile/chrome"
 
-if [[ ! -f "$output_file" ]]; then
-    cat > "$output_file" << EOF
+cat > "$output_file" << EOF
 :root {
 --color00: #${primary_background};
 --color01: #${primary_background};
@@ -51,14 +50,13 @@ if [[ ! -f "$output_file" ]]; then
 --color0F: #${bright_red};
 }
 EOF
-fi
 
 if [[ -d "$default_profile" ]]; then
     cp "$output_file" "$default_profile/chrome/colors.css"
 fi
 
 if [[ ! -f "$default_profile/chrome/userChrome.css" ]]; then
-    cat > "$default_profile/chrome/userChrome.css" << EOF
+cat > "$default_profile/chrome/userChrome.css" << EOF
 @import url("./colors.css");
 
 :root {
@@ -239,7 +237,7 @@ EOF
 fi
 
 if [[ ! -f "$default_profile/chrome/userContent.css" ]]; then
-    cat > "$default_profile/chrome/userContent.css" <<EOF
+cat > "$default_profile/chrome/userContent.css" <<EOF
 @import url("./colors.css");
 
 :root {

--- a/theme-set.d/40-steam.sh
+++ b/theme-set.d/40-steam.sh
@@ -10,8 +10,7 @@ if ! command -v python >/dev/null 2>&1; then
     skipped "Python 3"
 fi
 
-if [[ ! -f "$output_file" ]]; then
-    cat > "$output_file" << EOF
+cat > "$output_file" << EOF
 :root {
     /* The main accent color and the matching text value */
     --adw-accent-bg-rgb: ${rgb_normal_blue} !important;
@@ -92,7 +91,6 @@ if [[ ! -f "$output_file" ]]; then
     --adw-shade-a: 0.36 !important;
 }
 EOF
-fi
 
 adwaita_location=$HOME/.local/share/steam-adwaita
 font_path=$(fc-list $(omarchy-font-current) file | grep -ioP '.*\.ttf' | head -n 1)

--- a/theme-set.d/40-zen.sh
+++ b/theme-set.d/40-zen.sh
@@ -31,8 +31,7 @@ enable_userchrome
 
 mkdir -p "$default_profile/chrome"
 
-if [[ ! -f "$output_file" ]]; then
-    cat > "$output_file" << EOF
+cat > "$output_file" << EOF
 :root {
 --color00: #${primary_background};
 --color01: #${primary_background};
@@ -52,11 +51,10 @@ if [[ ! -f "$output_file" ]]; then
 --color0F: #${bright_red};
 }
 EOF
-fi
 cp "$output_file" "$default_profile/chrome/colors.css"
 
 if [[ ! -f "$default_profile/chrome/userChrome.css" ]]; then
-    cat > "$default_profile/chrome/userChrome.css" << EOF
+cat > "$default_profile/chrome/userChrome.css" << EOF
 @import url("./colors.css");
 
 :root {
@@ -238,7 +236,7 @@ EOF
 fi
 
 if [[ ! -f "$default_profile/chrome/userContent.css" ]]; then
-    cat > "$default_profile/chrome/userContent.css" <<EOF
+cat > "$default_profile/chrome/userContent.css" <<EOF
 @import url("./colors.css");
 
 :root {


### PR DESCRIPTION
## Summary

Omarchy 3.3 introduced a new template-based theming system that uses `yq` to render template files (*.tpl) with color values from colors.toml. This broke the theme hooks in two ways:

### 1. Color extraction from alacritty.toml no longer works

Previously, `theme-set` read colors from `alacritty.toml` which contained actual hex color values. In Omarchy 3.3+, `alacritty.toml` is generated from a template and may contain unrendered `{{ placeholder }}` syntax if `yq` is not installed or the template rendering fails.

**Fix:** Read colors directly from `colors.toml`, which is always a static file copied directly from the theme (not a rendered template).

### 2. File-exists checks prevent hooks from running

Many hooks used `if [[ ! -f "$output_file" ]]; then` to skip writing if the file already existed. This was intended to preserve user customizations, but Omarchy 3.3+ now creates these files during theme switching (even if they contain unrendered templates), so the hooks would skip and leave broken template syntax in config files.

**Fix:** Remove file-exists checks so hooks always regenerate config files with properly rendered colors from `colors.toml`.

## Additional changes

- Added `cursor_color`, `selection_foreground`, `selection_background` exports (available in Omarchy's `colors.toml`)
- Updated `10-ghostty.sh` to include cursor and selection colors

## Testing

Tested with Omarchy 3.3.1 on Arch Linux with multiple themes (catppuccin, everforest, etc.).

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)