### PR TITLE
Check for zeditor or zed and exit if absent

### DIFF
--- a/theme-set.d/20-zed.sh
+++ b/theme-set.d/20-zed.sh
@@ -112,8 +112,9 @@ cat > "$new_zed_file" << EOF
 EOF
 }
 
-if ! command -v zeditor >/dev/null 2>&1; then
+if ! command -v zeditor >/dev/null 2>&1 && ! command -v zed >/dev/null 2>&1; then
     skipped "Zed"
+    exit 0
 fi
 
 mkdir -p "$HOME/.config/zed/themes"


### PR DESCRIPTION
This pull request makes a small update to the Zed theme setup script to improve compatibility with different command names. Now, the script checks for both the `zeditor` and `zed` commands before proceeding, and exits early if neither is found.