### PR TITLE
Handle missing colors.toml for Omarchy 3.3+ themes

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,9 @@ curl -fsSL https://imbypass.github.io/omarchy-theme-hook/uninstall.sh | bash
 #### My Spotify stopped theming!
 A Spotify client update may have caused Spicetify to stop working. You can fix this either by running `spicetify restore backup apply` or by reinstalling Spotify and Spicetify, and running `spicetify backup apply`.
 
+#### I get a "colors.toml not found" error!
+Omarchy 3.3+ requires themes to include `colors.toml`. Update your theme to a version compatible with Omarchy 3.3+, or add a valid `colors.toml` file to the theme directory.
+
 #### What if I encounter issues?
 If you encounter any issues, please open an issue on the GitHub repository.
 

--- a/theme-set
+++ b/theme-set
@@ -5,6 +5,10 @@
 # from templates and may contain unrendered {{ placeholders }}.
 input_file="$HOME/.config/omarchy/current/theme/colors.toml"
 
+if [[ ! -f "$input_file" ]]; then
+    error "colors.toml not found at $input_file. Ensure your theme is compatible with Omarchy 3.3+ and includes colors.toml."
+fi
+
 # Extract color value from colors.toml (flat key=value format)
 extract_color() {
     local color_name="$1"


### PR DESCRIPTION
Adds a fail-fast check in theme-set for missing colors.toml with a clear error message. Also adds a README FAQ note explaining that Omarchy 3.3+ themes must include colors.toml.