### PR TITLE
fix(nwg-dock): move layout properties from colors.css to style.css

### DIFF
--- a/theme-set.d/20-nwg-dock-hyprland.sh
+++ b/theme-set.d/20-nwg-dock-hyprland.sh
@@ -50,23 +50,21 @@ if [[ ! -f "$output_file" ]]; then
 
   cat >"$output_file" <<EOF
 window {
-    background: #${primary_background}; /* base01 */
-    border-color: #${bright_black}; /* base02 */
-    border: 2px solid #${bright_black};
+    background: #${primary_background};
+    border-color: #${bright_black};
 }
 
 button,
 image {
-    color: #${bright_white}; /* base07 */
+    color: #${bright_white};
 }
 
 button {
-    color: #${normal_white}; /* base05 */
-    padding: 3px;
+    color: #${normal_white};
 }
 
 button:hover {
-    background-color: rgba($rgb_bright_black, 0.5); /* base02 */
+    background-color: rgba($rgb_bright_black, 0.5);
 }
 EOF
 
@@ -83,6 +81,9 @@ window {
 }
 
 #box {
+    border-style: solid;
+    border-width: 2px;
+    border-radius: 12px;
     padding: 6px;
 }
 


### PR DESCRIPTION
Fixes #47

Moves non-color properties (`border`, `padding`) from the colors.css template to style.css where they belong. Removes inline comments from the colors template.

**Changes:**
- Removed `border: 2px solid` and `padding: 3px` from colors template
- Added `border-style`, `border-width`, `border-radius` to `#box` in style.css template
- Colors template now only contains color-related properties